### PR TITLE
Riak documentaion elaboration: riak_kv_lru, vnode_cache_entries

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -67,6 +67,13 @@
             %% Value is in milliseconds and defaults to 1000ms if not set.
             %{vnode_mr_timeout, 1000},
 
+            %% vnode_cache_entries controls the number of entries in
+            %% the LRU cache of each vnode. The setting indirectly
+            %% affect the memory usage of each riak node; lower numbers use
+            %% less memory but may lead to slower operation. The default is
+            %% 100 cache entries per vnode.
+            %{vnode_cache_entries, 100},
+
             %% riak_stat enables the use of the "riak-admin status" command to
             %% retrieve information the Riak node for performance and debugging needs
             {riak_kv_stat, true}


### PR DESCRIPTION
You may want to pull this documentation elaboration to riak. A reason for not doing it could be to hide the knob from the user - so they don't go twiddling with knobs they should not play with.
