### PR TITLE
Reference to riak_err in rebar.conf was not publicly accessible

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,5 +9,5 @@
 {deps, [
        {luwak, "1.*", {git, "git://github.com/basho/luwak", "HEAD"}},
        {riak_kv, "0.13.0", {git, "git://github.com/basho/riak_kv", "HEAD"}},
-       {riak_err, ".*", {git, "git@github.com:/basho/riak_err", "HEAD"}}
+       {riak_err, ".*", {git, "git://github.com/basho/riak_err", "HEAD"}}
        ]}.


### PR DESCRIPTION
the repository for riak_err in rebar.conf was 'git@github.com:/basho/riak_err', which at least I couldn't pull from
