### PR TITLE
dss include gitvsn (take 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,8 +114,13 @@ buildtar = mkdir distdir && \
 		 $(call archive,$(RIAK_TAG),..) && \
 		 mkdir ../$(RIAK_TAG)/deps && \
 		 make deps; \
-		 for dep in deps/*; do cd $${dep} && $(call archive,$${dep},../../../$(RIAK_TAG)); cd ../..; done
-					 
+		 for dep in deps/*; do \
+                     cd $${dep} && \
+                     $(call archive,$${dep},../../../$(RIAK_TAG)) && \
+                     mkdir -p ../../../$(RIAK_TAG)/$${dep}/priv && \
+                     git rev-list --max-count=1 HEAD > ../../../$(RIAK_TAG)/$${dep}/priv/git.vsn && \
+                     cd ../..; done
+
 distdir:
 	$(if $(RIAK_TAG), $(call buildtar), $(error "You can't generate a release tarball from a non-tagged revision. Run 'git checkout <tag>', then 'make dist'"))
 


### PR DESCRIPTION
Include git.vsn when constructing package archives. This makes it possible for us to know what version of a given sub-repo was used during compilation and not have to do so many RCs.
