### PR TITLE
Bz982 - js_reload not working

### DIFF
--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -198,7 +198,8 @@ case "$1" in
             exit 1
         fi
 
-        $NODETOOL rpc riak_kv_js_manager reload
+        shift #optional names come after 'js_reload'
+        $NODETOOL rpc riak_kv_js_manager reload $@
         ;;
 
     reip)


### PR DESCRIPTION
Default 'riak-admin js_reload' functionality is to reload all VMs in all pools.  This patch allows you to specify a specific VM pool to reset.  For example, 'riak-admin js_reload riak_kv_js_map' will reload only the JS MVs in the map pool.

This patch requires the patch from https://github.com/basho/riak_kv/pull/30 to be in place.
