### PR TITLE
Bz997 erlcrashdump

### DIFF
--- a/package/deb/vars.config
+++ b/package/deb/vars.config
@@ -10,6 +10,7 @@
 {sasl_log_dir, "/var/log/riak/sasl"}.
 % vm.args
 {node,         "riak@127.0.0.1"}.
+{crash_dump,   "/var/log/riak/erl_crash.dump"}.
 % bin/riak*
 {runner_script_dir,  "/usr/sbin"}.
 {runner_base_dir,    "/usr/lib/riak"}.

--- a/package/rpm/SPECS/riak.spec
+++ b/package/rpm/SPECS/riak.spec
@@ -44,7 +44,7 @@ cat > rel/vars.config <<EOF
 {hook_js_vms, 2}.
 % vm.args
 {node,         "riak@127.0.0.1"}.
-{crash_dump,   "/var/log/riak/erl_crash.dump"}.
+{crash_dump,   "%{_localstatedir}/log/%{name}/erl_crash.dump"}.
 % bin/riak*
 {runner_script_dir,  "/usr/sbin"}.
 {runner_base_dir,    "%{riak_lib}"}.

--- a/package/rpm/SPECS/riak.spec
+++ b/package/rpm/SPECS/riak.spec
@@ -44,6 +44,7 @@ cat > rel/vars.config <<EOF
 {hook_js_vms, 2}.
 % vm.args
 {node,         "riak@127.0.0.1"}.
+{crash_dump,   "/var/log/riak/erl_crash.dump"}.
 % bin/riak*
 {runner_script_dir,  "/usr/sbin"}.
 {runner_base_dir,    "%{riak_lib}"}.

--- a/rel/files/vm.args
+++ b/rel/files/vm.args
@@ -19,3 +19,5 @@
 ## Tweak GC to run more often 
 -env ERL_FULLSWEEP_AFTER 0
 
+## Set the location of crash dumps
+-env ERL_CRASH_DUMP {{crash_dump}}

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -24,6 +24,7 @@
 %% etc/vm.args
 %%
 {node,         "riak@127.0.0.1"}.
+{crash_dump,   "log/erl_crash.dump"}.
 
 %%
 %% bin/riak

--- a/rel/vars/dev1_vars.config
+++ b/rel/vars/dev1_vars.config
@@ -24,6 +24,7 @@
 %% etc/vm.args
 %%
 {node,         "dev1@127.0.0.1"}.
+{crash_dump,   "log/erl_crash.dump"}.
 
 %%
 %% bin/riak

--- a/rel/vars/dev2_vars.config
+++ b/rel/vars/dev2_vars.config
@@ -24,6 +24,7 @@
 %% etc/vm.args
 %%
 {node,         "dev2@127.0.0.1"}.
+{crash_dump,   "log/erl_crash.dump"}.
 
 %%
 %% bin/riak

--- a/rel/vars/dev3_vars.config
+++ b/rel/vars/dev3_vars.config
@@ -24,6 +24,7 @@
 %% etc/vm.args
 %%
 {node,         "dev3@127.0.0.1"}.
+{crash_dump,   "log/erl_crash.dump"}.
 
 %%
 %% bin/riak


### PR DESCRIPTION
Puts the erl_crash.dump file in a writeable place for each platform so we don't lose information about hard crashes.
