### PR TITLE
Bz962 cluster info usage unclear

### DIFF
--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -145,6 +145,11 @@ case "$1" in
         ;;
 
     cluster_info)
+        if [ $# -lt 2 ]; then
+            echo "Usage: $SCRIPT cluster_info <output_file> ['local' | <node> ['local' | <node>] [...]]"
+            exit 1
+        fi
+
         # Make sure the local node IS running
         RES=`$NODETOOL ping`
         if [ "$RES" != "pong" ]; then


### PR DESCRIPTION
This change makes the usage for the cluster_info command more consistent with the other riak-admin commands.
