### PR TITLE
Make 'riak ping' exit with non-zero status if node doesn't respond

### DIFF
--- a/rel/files/riak
+++ b/rel/files/riak
@@ -120,7 +120,13 @@ case "$1" in
 
     ping)
         ## See if the VM is alive
-        $NODETOOL ping
+        RES=`$NODETOOL ping`
+        echo $RES
+        if [ "$RES" != "pong" ]; then
+            exit 1
+        else
+            exit 0
+        fi
         ;;
 
     attach)


### PR DESCRIPTION
I suggest making "riak ping" exit with non-zero status if the node doesn't respond to ease conditional scripting based on node status etc.
