### PR TITLE
Bz1077 nodetool ssl support

### DIFF
--- a/package/deb/vars.config
+++ b/package/deb/vars.config
@@ -8,6 +8,14 @@
 {bitcask_data_root, "/var/lib/riak/bitcask"}.
 {sasl_error_log, "/var/log/riak/sasl-error.log"}.
 {sasl_log_dir, "/var/log/riak/sasl"}.
+
+% Platform-specific installation paths
+{platform_bin_dir, "/usr/sbin"}.
+{platform_data_dir, "/var/lib/riak"}.
+{platform_etc_dir, "/etc/riak"}.
+{platform_lib_dir, "/usr/lib/riak"}.
+{platform_log_dir, "/var/log/riak"}.
+
 % vm.args
 {node,         "riak@127.0.0.1"}.
 % bin/riak*

--- a/package/rpm/SPECS/riak.spec
+++ b/package/rpm/SPECS/riak.spec
@@ -42,10 +42,16 @@ cat > rel/vars.config <<EOF
 {map_js_vms,   8}.
 {reduce_js_vms, 6}.
 {hook_js_vms, 2}.
+% Platform-specific installation paths
+{platform_bin_dir, "%{_sbindir}"}.
+{platform_data_dir, "%{_localstatedir}/lib/%{name}"}.
+{platform_etc_dir, "%{_sysconfdir}/%{name}"}.
+{platform_lib_dir, "%{riak_lib}"}.
+{platform_log_dir, "%{_localstatedir}/log/%{name}"}.
 % vm.args
 {node,         "riak@127.0.0.1"}.
 % bin/riak*
-{runner_script_dir,  "/usr/sbin"}.
+{runner_script_dir,  "%{_sbindir}"}.
 {runner_base_dir,    "%{riak_lib}"}.
 {runner_etc_dir,     "%{_sysconfdir}/%{name}"}.
 {runner_log_dir,     "%{_localstatedir}/log/%{name}"}.

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -23,7 +23,14 @@
               
               %% riak_handoff_port is the TCP port that Riak uses for
               %% intra-cluster data handoff.
-              {handoff_port, {{handoff_port}} }
+              {handoff_port, {{handoff_port}} },
+
+              %% Platform-specific installation paths (substituted by rebar)
+              {platform_bin_dir, "{{platform_bin_dir}}"},
+              {platform_data_dir, "{{platform_data_dir}}"},
+              {platform_etc_dir, "{{platform_etc_dir}}"},
+              {platform_lib_dir, "{{platform_lib_dir}}"},
+              {platform_log_dir, "{{platform_log_dir}}"}
              ]},
 
  %% Riak KV config

--- a/rel/files/nodetool
+++ b/rel/files/nodetool
@@ -1,4 +1,6 @@
+#!/usr/bin/env escript
 %% -*- erlang -*-
+%%! -args_file {{platform_data_dir}}/ssl_distribution.args_file
 %% -------------------------------------------------------------------
 %%
 %% nodetool: Helper Script for interacting with live nodes
@@ -8,6 +10,10 @@
 main(Args) ->
     %% Extract the args
     {RestArgs, TargetNode} = process_args(Args, [], undefined),
+
+    %% process_args() has side-effects (e.g. when processing "-name"),
+    %% so take care of app-starting business first.
+    [application:start(App) || App <- [crypto, public_key, ssl]],
 
     %% See if the node is currently running  -- if it's not, we'll bail
     case {net_kernel:hidden_connect_node(TargetNode), net_adm:ping(TargetNode)} of

--- a/rel/files/riak
+++ b/rel/files/riak
@@ -10,6 +10,7 @@ RUNNER_ETC_DIR={{runner_etc_dir}}
 RUNNER_LOG_DIR={{runner_log_dir}}
 PIPE_DIR={{pipe_dir}}
 RUNNER_USER={{runner_user}}
+SSL_DIST_CONFIG={{platform_data_dir}}/ssl_distribution.args_file
 
 # Make sure this script is running as the appropriate user
 if [ "$RUNNER_USER" -a "x$LOGNAME" != "x$RUNNER_USER" ]; then
@@ -63,6 +64,11 @@ ERTS_PATH=$RUNNER_BASE_DIR/erts-$ERTS_VSN/bin
 
 # Setup command to control the node
 NODETOOL="$ERTS_PATH/escript $ERTS_PATH/nodetool $NAME_ARG $COOKIE_ARG"
+
+# Scrape out SSL distribution config info from vm.args into $SSL_DIST_CONFIG
+rm -f $SSL_DIST_CONFIG
+sed -n '/Begin SSL distribution items/,/End SSL distribution items/p' \
+    $RUNNER_ETC_DIR/vm.args > $SSL_DIST_CONFIG
 
 # Check the first argument for instructions
 case "$1" in

--- a/rel/files/vm.args
+++ b/rel/files/vm.args
@@ -1,4 +1,3 @@
-
 ## Name of the riak node
 -name {{node}}
 
@@ -18,4 +17,16 @@
 
 ## Tweak GC to run more often 
 -env ERL_FULLSWEEP_AFTER 0
+
+## Begin SSL distribution items, DO NOT DELETE OR EDIT THIS COMMENT
+
+## To enable SSL encryption of the Erlang intra-cluster communication,
+## un-comment the three lines below and make certain that the paths
+## point to correct PEM data files.  See docs TODO for details.
+
+## -proto_dist inet_ssl
+## -ssl_dist_opt client_certfile "{{platform_etc_dir}}/erlclient.pem"
+## -ssl_dist_opt server_certfile "{{platform_etc_dir}}/erlserver.pem"
+
+## End SSL distribution items, DO NOT DELETE OR EDIT THIS COMMENT
 

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -57,11 +57,11 @@
            {mkdir, "data/ring"},
            {mkdir, "log/sasl"},
            {copy, "files/erl", "{{erts_vsn}}/bin/erl"},
-           {copy, "files/nodetool", "{{erts_vsn}}/bin/nodetool"},
            {template, "files/app.config", "etc/app.config"},
-           {template, "files/vm.args", "etc/vm.args"},
+           {template, "files/nodetool", "{{erts_vsn}}/bin/nodetool"},
            {template, "files/riak", "bin/riak"},
-           {template, "files/riak-admin", "bin/riak-admin"}
+           {template, "files/riak-admin", "bin/riak-admin"},
+           {template, "files/vm.args", "etc/vm.args"}
           ]}.
 
 

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -20,6 +20,13 @@
 {reduce_js_vms, 6}.
 {hook_js_vms, 2}.
 
+%% Platform-specific installation paths
+{platform_bin_dir, "./bin"}.
+{platform_data_dir, "./data"}.
+{platform_etc_dir, "./etc"}.
+{platform_lib_dir, "./lib"}.
+{platform_log_dir, "./log"}.
+
 %%
 %% etc/vm.args
 %%

--- a/rel/vars/dev1_vars.config
+++ b/rel/vars/dev1_vars.config
@@ -20,6 +20,13 @@
 {reduce_js_vms, 6}.
 {hook_js_vms, 2}.
 
+%% Platform-specific installation paths
+{platform_bin_dir, "./bin"}.
+{platform_data_dir, "./data"}.
+{platform_etc_dir, "./etc"}.
+{platform_lib_dir, "./lib"}.
+{platform_log_dir, "./log"}.
+
 %%
 %% etc/vm.args
 %%

--- a/rel/vars/dev2_vars.config
+++ b/rel/vars/dev2_vars.config
@@ -20,6 +20,13 @@
 {reduce_js_vms, 6}.
 {hook_js_vms, 2}.
 
+%% Platform-specific installation paths
+{platform_bin_dir, "./bin"}.
+{platform_data_dir, "./data"}.
+{platform_etc_dir, "./etc"}.
+{platform_lib_dir, "./lib"}.
+{platform_log_dir, "./log"}.
+
 %%
 %% etc/vm.args
 %%

--- a/rel/vars/dev3_vars.config
+++ b/rel/vars/dev3_vars.config
@@ -20,6 +20,13 @@
 {reduce_js_vms, 6}.
 {hook_js_vms, 2}.
 
+%% Platform-specific installation paths
+{platform_bin_dir, "./bin"}.
+{platform_data_dir, "./data"}.
+{platform_etc_dir, "./etc"}.
+{platform_lib_dir, "./lib"}.
+{platform_log_dir, "./log"}.
+
 %%
 %% etc/vm.args
 %%


### PR DESCRIPTION
Basho reviewer: dev or DA, someone familiar with Riak packaging is a plus.

The new OTP app env vars to riak_core, named platform_*_dir, aren't used
directly by nodetool, but they're things that I've long wanted basho_expect to
have access to.  Since I was mucking around with the rebar template stuff, I
added them.

Nodetool needs to use the same SSL config items (from the "vm.args" file)
that the riak VM needs, except that it can't use the "vm.args" file as-is because
it contains stuff that nodetool cannot use, e.g. "-name foo@bar".  Therefore,
I use a "sed" hack to strip out the SSL config stuff from "vm.args" and put it
into a temp file that nodetool can use.  Each time the "riak" script is run, that
temp file is created, which should allow "vm.args" to be the single place
where this config info should be maintained.

If this packaging looks sane, then I'll apply the same changes to RiakEE and
RiakSearch packaging.  I haven't done so yet because reviewers might have
substantial recommentations for more work.

Possible todo items:

```
1. Put the docs in the 2nd commit into another, more accessible place
1. Is there a better style/method for managing the key files?
```
