### PR TITLE
AZ 307: SSL encryption of riak_core handoff traffic

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -25,6 +25,12 @@
               %% intra-cluster data handoff.
               {handoff_port, {{handoff_port}} },
 
+              %% To encrypt riak_core intra-cluster data handoff traffic,
+              %% uncomment the following line and edit its path to an
+              %% appropriate certfile and keyfile.  (This example uses a
+              %% single file with both items concatenated together.)
+              %{handoff_ssl_options, [{certfile, "/tmp/erlserver.pem"}]},
+
               %% Platform-specific installation paths (substituted by rebar)
               {platform_bin_dir, "{{platform_bin_dir}}"},
               {platform_data_dir, "{{platform_data_dir}}"},

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -7,6 +7,8 @@
          kernel,
          stdlib,
          sasl,
+         public_key,
+         ssl,
          riak_err,
          riak_sysmon,
          os_mon,


### PR DESCRIPTION
Config & reltool changes require to support riak_core/az307-handoff-ssl.
See also: https://github.com/basho/riak_core/pull/50
