### PR TITLE
make four dev nodes, not three

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,13 +34,13 @@ relclean:
 ##
 ## Developer targets
 ##
-stagedevrel: dev1 dev2 dev3
+stagedevrel: dev1 dev2 dev3 dev4
 	$(foreach dev,$^,\
 	  $(foreach dep,$(wildcard deps/*), rm -rf dev/$(dev)/lib/$(shell basename $(dep))-* && ln -sf $(abspath $(dep)) dev/$(dev)/lib;))
 
-devrel: dev1 dev2 dev3
+devrel: dev1 dev2 dev3 dev4
 
-dev1 dev2 dev3:
+dev1 dev2 dev3 dev4:
 	mkdir -p dev
 	(cd rel && ../rebar generate target_dir=../dev/$@ overlay_vars=vars/$@_vars.config)
 

--- a/rel/vars/dev4_vars.config
+++ b/rel/vars/dev4_vars.config
@@ -1,0 +1,36 @@
+%% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
+
+%%
+%% etc/app.config
+%%
+{ring_state_dir,    "data/ring"}.
+{web_ip,            "127.0.0.1"}.
+{web_port,          8094}.
+{handoff_port,      8104}.
+{pb_ip,             "127.0.0.1"}.
+{pb_port,           8084}.
+{bitcask_data_root, "data/bitcask"}.
+{sasl_error_log,    "log/sasl-error.log"}.
+{sasl_log_dir,      "log/sasl"}.
+{mapred_queue_dir, "data/mr_queue"}.
+
+%% Javascript VMs
+{map_js_vms,   8}.
+{reduce_js_vms, 6}.
+{hook_js_vms, 2}.
+
+%%
+%% etc/vm.args
+%%
+{node,         "dev4@127.0.0.1"}.
+
+%%
+%% bin/riak
+%%
+{runner_script_dir,  "$(cd ${0%/*} && pwd)"}.
+{runner_base_dir,    "${RUNNER_SCRIPT_DIR%/*}"}.
+{runner_etc_dir,     "$RUNNER_BASE_DIR/etc"}.
+{runner_log_dir,     "$RUNNER_BASE_DIR/log"}.
+{pipe_dir,           "/tmp/$RUNNER_BASE_DIR/"}.
+{runner_user,        ""}.


### PR DESCRIPTION
four nodes produce slightly different cluster behavior, since they
divide a power-of-two partition count evenly; useful for testing
