### PR TITLE
set mapred_system=pipe by default in new app.config

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -68,9 +68,16 @@
             %% mapred_name is URL used to submit map/reduce requests to Riak.
             {mapred_name, "mapred"},
 
+            %% mapred_system indicates which version of the MapReduce
+            %% system should be used: 'pipe' means riak_pipe will
+            %% power MapReduce queries, while 'legacy' means that luke
+            %% will be used
+            {mapred_system, pipe},
+
             %% directory used to store a transient queue for pending
             %% map tasks
-            {mapred_queue_dir, "{{mapred_queue_dir}}" },
+            %% Only valid when mapred_system == legacy
+            %% {mapred_queue_dir, "{{mapred_queue_dir}}" },
 
             %% Each of the following entries control how many Javascript
             %% virtual machines are available for executing map, reduce,
@@ -82,7 +89,8 @@
             %% Number of items the mapper will fetch in one request.
             %% Larger values can impact read/write performance for
             %% non-MapReduce requests.
-            {mapper_batch_size, 5},
+            %% Only valid when mapred_system == legacy
+            %% {mapper_batch_size, 5},
 
             %% js_max_vm_mem is the maximum amount of memory, in megabytes,
             %% allocated to the Javascript VMs. If unset, the default is
@@ -97,7 +105,8 @@
             %% Number of objects held in the MapReduce cache. These will be
             %% ejected when the cache runs out of room or the bucket/key
             %% pair for that entry changes
-            {map_cache_size, 10000},
+            %% Only valid when mapred_system == legacy
+            %% {map_cache_size, 10000},
 
             %% js_source_dir should point to a directory containing Javascript
             %% source files which will be loaded by Riak when it initializes


### PR DESCRIPTION
Now that riak_pipe is included in master, we could switch to using it by default.  This patch does so, and also comments out the legacy-specific MapReduce configs in app.config as well.
