### PR TITLE
riak_pipe build dependency for rebar.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,5 +13,6 @@
        {luwak, "1.*", {git, "git://github.com/basho/luwak", {branch, "master"}}},
        {riak_kv, "0.14.*", {git, "git://github.com/basho/riak_kv", {branch, "master"}}},
        {riak_search, "0.14.*", {git, "git://github.com/basho/riak_search",
-                                {branch, "master"}}}
+                                {branch, "master"}}},
+       {riak_pipe, "0.9.*", {git, "git://github.com/basho/riak_pipe", {branch, "master"}}}
        ]}.


### PR DESCRIPTION
After trying to `make rel` and getting an error I noticed that riak_pipe wasn't being pulled in. I added it to `rebar.config`. I'm assuming this was the place for it and not a sub dependency.
