### PR TITLE
AZ567 - Update 2i merge_index data_root setting.

### DIFF
--- a/package/deb/vars.config
+++ b/package/deb/vars.config
@@ -17,9 +17,8 @@
 {sasl_error_log,        "{{platform_log_dir}}/sasl-error.log"}.
 {sasl_log_dir,          "{{platform_log_dir}}/sasl"}.
 {mapred_queue_dir,      "{{platform_data_dir}}/mr_queue"}.
-
-%% riak_search
 {merge_index_data_root, "{{platform_data_dir}}/merge_index"}.
+{merge_index_data_root_2i, "{{platform_data_dir}}/merge_index_2i"}.
 
 %% Javascript VMs
 {map_js_vms,   8}.

--- a/package/rpm/SPECS/riak.spec
+++ b/package/rpm/SPECS/riak.spec
@@ -44,7 +44,8 @@ cat > rel/vars.config <<EOF
 {ring_state_dir,        "%{platform_data_dir}/ring"}.
 {bitcask_data_root,     "%{platform_data_dir}/bitcask"}.
 {leveldb_data_root,     "%{platform_data_dir}/leveldb"}.
-{merge_index_data_root, "%{platform_data_dir}/merge_index"}.
+{merge_index_data_root,    "%{platform_data_dir}/merge_index"}.
+{merge_index_data_root_2i, "%{platform_data_dir}/merge_index_2i"}.
 {sasl_error_log,        "%{platform_log_dir}/sasl-error.log"}.
 {sasl_log_dir,          "%{platform_log_dir}/sasl"}.
 {mapred_queue_dir,      "%{platform_data_dir}/mr_queue"}.

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -132,8 +132,11 @@
 
  %% Merge Index Config
  {merge_index, [
-                %% The root dir to store merge_index data
+                %% The root dir to store search merge_index data
                 {data_root, "{{merge_index_data_root}}"},
+
+                %% The root dir to store secondary index merge_index data
+                {data_root_2i, "{{merge_index_data_root_2i}}"},
 
                 %% Size, in bytes, of the in-memory buffer.  When this
                 %% threshold has been reached the data is transformed

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -26,6 +26,9 @@
 %% riak_search
 {merge_index_data_root,  "{{platform_data_dir}}/merge_index"}.
 
+%% secondary indices
+{merge_index_data_root_2i,  "{{platform_data_dir}}/merge_index_2i"}.
+
 %% Javascript VMs
 {map_js_vms,   8}.
 {reduce_js_vms, 6}.

--- a/rel/vars/dev1_vars.config
+++ b/rel/vars/dev1_vars.config
@@ -22,9 +22,8 @@
 {sasl_error_log,    "{{platform_log_dir}}/sasl-error.log"}.
 {sasl_log_dir,      "{{platform_log_dir}}/sasl"}.
 {mapred_queue_dir,  "{{platform_data_dir}}/mr_queue"}.
-
-%% riak_search
 {merge_index_data_root,  "{{platform_data_dir}}/merge_index"}.
+{merge_index_data_root_2i,  "{{platform_data_dir}}/merge_index_2i"}.
 
 %% Javascript VMs
 {map_js_vms,   8}.

--- a/rel/vars/dev2_vars.config
+++ b/rel/vars/dev2_vars.config
@@ -22,9 +22,8 @@
 {sasl_error_log,    "{{platform_log_dir}}/sasl-error.log"}.
 {sasl_log_dir,      "{{platform_log_dir}}/sasl"}.
 {mapred_queue_dir,  "{{platform_data_dir}}/mr_queue"}.
-
-%% riak_search
 {merge_index_data_root,  "{{platform_data_dir}}/merge_index"}.
+{merge_index_data_root_2i,  "{{platform_data_dir}}/merge_index_2i"}.
 
 %% Javascript VMs
 {map_js_vms,   8}.

--- a/rel/vars/dev3_vars.config
+++ b/rel/vars/dev3_vars.config
@@ -22,9 +22,8 @@
 {sasl_error_log,    "{{platform_log_dir}}/sasl-error.log"}.
 {sasl_log_dir,      "{{platform_log_dir}}/sasl"}.
 {mapred_queue_dir,  "{{platform_data_dir}}/mr_queue"}.
-
-%% riak_search
 {merge_index_data_root,  "{{platform_data_dir}}/merge_index"}.
+{merge_index_data_root_2i,  "{{platform_data_dir}}/merge_index_2i"}.
 
 %% Javascript VMs
 {map_js_vms,   8}.

--- a/rel/vars/dev4_vars.config
+++ b/rel/vars/dev4_vars.config
@@ -22,9 +22,8 @@
 {sasl_error_log,    "{{platform_log_dir}}/sasl-error.log"}.
 {sasl_log_dir,      "{{platform_log_dir}}/sasl"}.
 {mapred_queue_dir,  "{{platform_data_dir}}/mr_queue"}.
-
-%% riak_search
 {merge_index_data_root,  "{{platform_data_dir}}/merge_index"}.
+{merge_index_data_root_2i,  "{{platform_data_dir}}/merge_index_2i"}.
 
 %% Javascript VMs
 {map_js_vms,   8}.


### PR DESCRIPTION
With 2i, we now run an additional merge_index instances. This change sets the 2i instances to point to a different data_root than the search instances.
