### PR TITLE
Added sudo-dependency for Debian packages

### DIFF
--- a/package/deb/control
+++ b/package/deb/control
@@ -8,7 +8,7 @@ Homepage: http://basho.com/
 
 Package: riak
 Architecture: any
-Depends: adduser, logrotate, ${shlibs:Depends}, ${misc:Depends}
+Depends: adduser, logrotate, ${shlibs:Depends}, ${misc:Depends}, sudo
 Description: Distributed data store written in Erlang
   Riak combines a decentralized key-value store, a flexible map/reduce engine, 
   and a friendly HTTP/JSON query interface to provide a database ideally suited 


### PR DESCRIPTION
The command-line utilities `riak` and `riak-admin` uses `sudo`, so it should be a dependency...
