### PR TITLE
Az520 md5 checksum on package

### DIFF
--- a/package/deb/Makefile
+++ b/package/deb/Makefile
@@ -13,8 +13,8 @@ build:  $(BUILDPATH)/debian \
 		-uc -us
 	mkdir -p packages
 	mv debuild/$(APP)_$(REVISION)-$(RELEASE)_*.deb packages
-	cd packages && md5sum $(APP)_$(REVISION)-$(RELEASE)_*.deb \
-            > `ls $(APP)_$(REVISION)-$(RELEASE)_*.deb`.md5
+	cd packages && sha256sum $(APP)_$(REVISION)-$(RELEASE)_*.deb \
+            > `ls $(APP)_$(REVISION)-$(RELEASE)_*.deb`.sha
 
 $(BUILDPATH): $(APP)-$(REVISION).tar.gz
 	mkdir -p debuild

--- a/package/deb/Makefile
+++ b/package/deb/Makefile
@@ -13,6 +13,8 @@ build:  $(BUILDPATH)/debian \
 		-uc -us
 	mkdir -p packages
 	mv debuild/$(APP)_$(REVISION)-$(RELEASE)_*.deb packages
+	cd packages && md5sum $(APP)_$(REVISION)-$(RELEASE)_*.deb \
+            > `ls $(APP)_$(REVISION)-$(RELEASE)_*.deb`.md5)
 
 $(BUILDPATH): $(APP)-$(REVISION).tar.gz
 	mkdir -p debuild

--- a/package/deb/Makefile
+++ b/package/deb/Makefile
@@ -13,8 +13,10 @@ build:  $(BUILDPATH)/debian \
 		-uc -us
 	mkdir -p packages
 	mv debuild/$(APP)_$(REVISION)-$(RELEASE)_*.deb packages
-	cd packages && sha256sum $(APP)_$(REVISION)-$(RELEASE)_*.deb \
-            > `ls $(APP)_$(REVISION)-$(RELEASE)_*.deb`.sha
+	cd packages && \
+		for debfile in `ls *.deb`; do \
+			sha256sum $${debfile} > $${debfile}.sha \
+		; done
 
 $(BUILDPATH): $(APP)-$(REVISION).tar.gz
 	mkdir -p debuild

--- a/package/deb/Makefile
+++ b/package/deb/Makefile
@@ -14,7 +14,7 @@ build:  $(BUILDPATH)/debian \
 	mkdir -p packages
 	mv debuild/$(APP)_$(REVISION)-$(RELEASE)_*.deb packages
 	cd packages && md5sum $(APP)_$(REVISION)-$(RELEASE)_*.deb \
-            > `ls $(APP)_$(REVISION)-$(RELEASE)_*.deb`.md5)
+            > `ls $(APP)_$(REVISION)-$(RELEASE)_*.deb`.md5
 
 $(BUILDPATH): $(APP)-$(REVISION).tar.gz
 	mkdir -p debuild

--- a/package/rpm/Makefile
+++ b/package/rpm/Makefile
@@ -19,7 +19,7 @@ build: $(PKGERDIR)/SOURCES/$(APP)-$(REVISION).tar.gz rpmbuild
 		 -ba $(PKGERDIR)/SPECS/$(APP).spec
 	cd packages && \
 		for rpmfile in `ls *.rpm`; do \
-			md5sum $${rpmfile} > $${rpmfile}.md5 \
+			sha256sum $${rpmfile} > $${rpmfile}.sha \
 		; done
 
 rpmbuild:

--- a/package/rpm/Makefile
+++ b/package/rpm/Makefile
@@ -17,6 +17,10 @@ build: $(PKGERDIR)/SOURCES/$(APP)-$(REVISION).tar.gz rpmbuild
 		 --define "_version $(PKG_VERSION)" \
 		 --define "_release $(RELEASE)" \
 		 -ba $(PKGERDIR)/SPECS/$(APP).spec
+	cd packages && \
+		for rpmfile in `ls *.rpm`; do \
+			md5sum $${rpmfile} > $${rpmfile}.md5 \
+		; done
 
 rpmbuild:
 	@mkdir -p rpmbuild/BUILD

--- a/package/solaris/Makefile
+++ b/package/solaris/Makefile
@@ -17,7 +17,7 @@ build: buildrel depend pkginfo prototype
 	@echo
 	@echo Wrote: $(CURDIR)/packages/$(PKGFILE).gz
 	@echo
-	cd packages && digest -a md5 -v $(PKGFILE).gz > $(PKGFILE).gz.md5
+	cd packages && echo "`digest -a md5 $(PKGFILE).gz` $(PKGFILE).gz" > $(PKGFILE).gz.md5
 
 # Build the release we need to package
 buildrel:

--- a/package/solaris/Makefile
+++ b/package/solaris/Makefile
@@ -17,7 +17,7 @@ build: buildrel depend pkginfo prototype
 	@echo
 	@echo Wrote: $(CURDIR)/packages/$(PKGFILE).gz
 	@echo
-	cd packages && echo "`digest -a md5 $(PKGFILE).gz`  $(PKGFILE).gz" > $(PKGFILE).gz.md5
+	cd packages && echo "`digest -a sha256 $(PKGFILE).gz`  $(PKGFILE).gz" > $(PKGFILE).gz.sha
 
 # Build the release we need to package
 buildrel:

--- a/package/solaris/Makefile
+++ b/package/solaris/Makefile
@@ -17,7 +17,7 @@ build: buildrel depend pkginfo prototype
 	@echo
 	@echo Wrote: $(CURDIR)/packages/$(PKGFILE).gz
 	@echo
-	cd packages && echo "`digest -a md5 $(PKGFILE).gz` $(PKGFILE).gz" > $(PKGFILE).gz.md5
+	cd packages && echo "`digest -a md5 $(PKGFILE).gz`  $(PKGFILE).gz" > $(PKGFILE).gz.md5
 
 # Build the release we need to package
 buildrel:

--- a/package/solaris/Makefile
+++ b/package/solaris/Makefile
@@ -17,6 +17,7 @@ build: buildrel depend pkginfo prototype
 	@echo
 	@echo Wrote: $(CURDIR)/packages/$(PKGFILE).gz
 	@echo
+	cd packages && digest -a md5 -v $(PKGFILE).gz > $(PKGFILE).gz.md5
 
 # Build the release we need to package
 buildrel:


### PR DESCRIPTION
We are getting upload errors to our build hosting on S3 so this creates md5 sums for each package we build.   
