### PR TITLE
Modified .gitignore to also ignore the dev/ folder used when making dev* 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 deps/*
 rel/riak
-
+dev/


### PR DESCRIPTION
Modified .gitignore to also ignore the dev/ folder used when making dev\* targets.
