### PR TITLE
az://303 vclock enhancements redux be2 membership

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -125,6 +125,12 @@
             %% retrieve information the Riak node for performance and debugging needs
             {riak_kv_stat, true},
             {legacy_stats, false},
+
+            %% Switch to vnode-based vclocks rather than client ids.  This
+            %% significantly reduces the number of vclock entries.
+            %% Only set true if *all* nodes in the cluster are upgraded to 1.0
+            {vnode_vclocks, true},
+
             %% This option enables compatability of bucket and key listing
             %% with 0.14 and earlier versions. Once a rolling upgrade to
             %% a version > 0.14 is completed for a cluster, this should be 


### PR DESCRIPTION
New clusters will start with vnode-based vclocks, old
clusters will need to be upgraded manually.
