### PR TITLE
Add a backend_status command to riak-admin.

### DIFF
--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -151,6 +151,23 @@ case "$1" in
         $NODETOOL rpc riak_kv_console status $@
         ;;
 
+    vnode-status)
+        if [ $# -ne 1 ]; then
+            echo "Usage: $SCRIPT vnode-status"
+            exit 1
+        fi
+
+        # Make sure the local node IS running
+        RES=`$NODETOOL ping`
+        if [ "$RES" != "pong" ]; then
+            echo "Node is not running!"
+            exit 1
+        fi
+        shift
+
+        $NODETOOL rpc riak_kv_console vnode_status $@
+        ;;
+
     ringready)
         if [ $# -ne 1 ]; then
             echo "Usage: $SCRIPT ringready"


### PR DESCRIPTION
Add a backend_status command to riak-admin that fetches the status of
the backend for each available vnode. The vnode index, the backend,
and the data returned from calling the backend module's status
function are displayed.
