### PR TITLE
Adjust PID detection

### DIFF
--- a/rel/files/riak
+++ b/rel/files/riak
@@ -138,12 +138,12 @@ case "$1" in
             Linux|Darwin|FreeBSD|DragonFly|NetBSD|OpenBSD)
                 # PID COMMAND
                 PID=`ps ax -o pid= -o command=|\
-                    grep "$RUNNER_BASE_DIR/.*/[b]eam"|awk '{print $1}'`
+                    grep "\-config\ $RUNNER_ETC_DIR/app.config"|awk '{print $1}'`
                 ;;
             SunOS)
                 # PID COMMAND
                 PID=`ps -ef -o pid= -o args=|\
-                    grep "$RUNNER_BASE_DIR/.*/[b]eam"|awk '{print $1}'`
+                    grep "\-config\ $RUNNER_ETC_DIR/app.config"|awk '{print $1}'`
                 ;;
         esac
         $NODETOOL stop


### PR DESCRIPTION
This changes how the OS pid of the Erlang VM is detected, using the location of `app.config` instead of `beam`. This is a stopgap measure until we can get real pid files.

The rationale for this change is related to new aspects of Ripple's "test server", which generates nodes that share the same code/binary path but different `etc` and `data` directories. What has changed is that it no longer runs the generated node as a child process, making possible project-specific "development" clusters as well as "test" nodes that stay running between executions of the test suite. However, the ability to detect the pid as a child process has been lost. The sharing of executables makes detection of the ERTS/beam location insufficient for determining the correct pid to wait for.
