### PR TITLE
Change 'riak-admin remove' to 'riak-admin force-remove'

### DIFF
--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -103,8 +103,19 @@ case "$1" in
         ;;
 
     remove)
+        echo "The 'remove' command no longer exists. If you want a node to"
+        echo "safely leave the cluster (handoff its data before exiting),"
+        echo "then execute 'leave' on the desired node. If a node is down and"
+        echo "unrecoverable (and therefore cannot be safely removed), then"
+        echo "use the 'force-remove' command. A force removal drops all data"
+        echo "owned by the removed node. Read-repair can be used to restore"
+        echo "lost replicas."
+        exit 1
+        ;;
+
+    force-remove)
         if [ $# -ne 2 ]; then
-            echo "Usage: $SCRIPT remove <node>"
+            echo "Usage: $SCRIPT force-remove <node>"
             exit 1
         fi
 
@@ -378,7 +389,7 @@ case "$1" in
     *)
         echo "Usage: $SCRIPT { join | leave | backup | restore | test | status | "
         echo "                    reip | js_reload | wait-for-service | ringready | "
-        echo "                    transfers | remove | down | cluster_info | "
+        echo "                    transfers | force-remove | down | cluster_info | "
         echo "                    member_status | ring_status | vnode-status}"
         exit 1
         ;;


### PR DESCRIPTION
riak-admin remove in 1.0 immediately drops replicas, which is different behavior than remove in 0.14.2. To ensure users are aware of this change, remove is renamed to force-remove and a message is printed if the old remove command is used (directing user to either leave or force-remove).
