### PR TITLE
BSD support

### DIFF
--- a/rel/files/erl
+++ b/rel/files/erl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 ## This script replaces the default "erl" in erts-VSN/bin. This is necessary
 ## as escript depends on erl and in turn, erl depends on having access to a

--- a/rel/files/erl
+++ b/rel/files/erl
@@ -1,5 +1,14 @@
 #!/bin/sh
 
+# /bin/sh on Solaris is not a POSIX compatible shell, but /usr/bin/ksh is.
+if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
+    POSIX_SHELL="true"
+    export POSIX_SHELL
+    exec /usr/bin/ksh $0 $@
+fi
+unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
+
+
 ## This script replaces the default "erl" in erts-VSN/bin. This is necessary
 ## as escript depends on erl and in turn, erl depends on having access to a
 ## bootscript (start.boot). Note that this script is ONLY invoked as a side-effect

--- a/rel/files/erl
+++ b/rel/files/erl
@@ -4,7 +4,7 @@
 if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
     POSIX_SHELL="true"
     export POSIX_SHELL
-    exec /usr/bin/ksh $0 $@
+    exec /usr/bin/ksh $0 "$@"
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 

--- a/rel/files/riak
+++ b/rel/files/riak
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # -*- tab-width:4;indent-tabs-mode:nil -*-
 # ex: ts=4 sw=4 et
 

--- a/rel/files/riak
+++ b/rel/files/riak
@@ -2,6 +2,14 @@
 # -*- tab-width:4;indent-tabs-mode:nil -*-
 # ex: ts=4 sw=4 et
 
+# /bin/sh on Solaris is not a POSIX compatible shell, but /usr/bin/ksh is.
+if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
+    POSIX_SHELL="true"
+    export POSIX_SHELL
+    exec /usr/bin/ksh $0 $@
+fi
+unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
+
 RUNNER_SCRIPT_DIR={{runner_script_dir}}
 RUNNER_SCRIPT=${0##*/}
 

--- a/rel/files/riak
+++ b/rel/files/riak
@@ -6,7 +6,7 @@
 if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
     POSIX_SHELL="true"
     export POSIX_SHELL
-    exec /usr/bin/ksh $0 $@
+    exec /usr/bin/ksh $0 "$@"
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 

--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 RUNNER_SCRIPT_DIR={{runner_script_dir}}
 RUNNER_SCRIPT=${0##*/}

--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+# /bin/sh on Solaris is not a POSIX compatible shell, but /usr/bin/ksh is.
+if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
+    POSIX_SHELL="true"
+    export POSIX_SHELL
+    exec /usr/bin/ksh $0 $@
+fi
+unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
+
 RUNNER_SCRIPT_DIR={{runner_script_dir}}
 RUNNER_SCRIPT=${0##*/}
 

--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -4,7 +4,7 @@
 if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
     POSIX_SHELL="true"
     export POSIX_SHELL
-    exec /usr/bin/ksh $0 $@
+    exec /usr/bin/ksh $0 "$@"
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 

--- a/rel/files/search-cmd
+++ b/rel/files/search-cmd
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 ORIGINAL_DIR=$(pwd)
 RUNNER_SCRIPT_DIR={{runner_script_dir}}

--- a/rel/files/search-cmd
+++ b/rel/files/search-cmd
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+# /bin/sh on Solaris is not a POSIX compatible shell, but /usr/bin/ksh is.
+if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
+    POSIX_SHELL="true"
+    export POSIX_SHELL
+    exec /usr/bin/ksh $0 $@
+fi
+unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
+
 ORIGINAL_DIR=$(pwd)
 RUNNER_SCRIPT_DIR={{runner_script_dir}}
 RUNNER_SCRIPT=${0##*/}

--- a/rel/files/search-cmd
+++ b/rel/files/search-cmd
@@ -4,7 +4,7 @@
 if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
     POSIX_SHELL="true"
     export POSIX_SHELL
-    exec /usr/bin/ksh $0 $@
+    exec /usr/bin/ksh $0 "$@"
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 


### PR DESCRIPTION
Don't use /bin/bash in the shebang, use /bin/sh (and add a crazy workaround for Solaris' /bin/sh not actually being a POSIX shell).
