### PR TITLE
Use nodetool's rpc_infinity method when calling cluster_info

### DIFF
--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -261,7 +261,7 @@ case "$1" in
         fi
         shift
 
-        $NODETOOL rpc riak_kv_console cluster_info $@
+        $NODETOOL rpc_infinity riak_kv_console cluster_info $@
         ;;
 
     services)


### PR DESCRIPTION
Subject says it all, almost: without this patch, a 60 second timeout is
used, which is far too short for large clusters and/or slow nodes.
