### PR TITLE
Add 'riak version' command

### DIFF
--- a/RELEASE-NOTES.org
+++ b/RELEASE-NOTES.org
@@ -1,5 +1,6 @@
 * Riak 1.0.1 Release Notes
 ** Bugs Fixed
+-[[https://issues.basho.com/show_bug.cgi?id=15][bz0015 - Merge js-mapreduce.org and basic-mapreduce.txt]]
 -[[https://issues.basho.com/show_bug.cgi?id=1183][bz1183 - Handoff may cause riak_kv_w_reduce to over-reduce]]
 -[[https://issues.basho.com/show_bug.cgi?id=1184][bz1184 - riak_kv_w_reduce should respect reduce_phase_only_1 during handoff]]
 -[[https://issues.basho.com/show_bug.cgi?id=1213][bz1213 - HTTP and Javascript map phases can't use do_prereduce]]

--- a/package/Makefile
+++ b/package/Makefile
@@ -2,26 +2,36 @@ OS		= $(shell uname -s)
 KERNEL		= $(shell uname -r)
 ERLANG_BIN	= $(shell dirname $(shell which erl))
 ifeq ($(OS),Linux)
+ARCH		= $(shell uname -m)
 PKGER		= $(shell cat /etc/redhat-release 2> /dev/null)
 ifeq ($(PKGER),)
+OSNAME		= Debian
 PKGER		= debuild
 PKGERDIR	= deb
 else
+OSNAME		= RedHat
 PKGER		= rpmbuild
 PKGERDIR	= rpm
 endif
 endif
 ifeq ($(OS),SunOS)
+ARCH		= $(shell uname -p)
 PKGER		= make
 PKGERDIR	= solaris
 DISTRO		= $(shell head -1 /etc/release|awk \
                    '{if ($$1 == "OpenSolaris") {print $$1} else {print "Solaris"}}')
+OSNAME		= ${DISTRO}
 endif
 ifeq ($(OS),Darwin)
-PKGER           = make
-PKGERDIR        = osx
-BUILDDIR        = osxbuild
+OSNAME		= OSX
+ARCH		= $(shell uname -m)
+PKGER		= make
+PKGERDIR	= osx
+BUILDDIR	= osxbuild
 endif
+
+DATE		= $(shell date +%Y-%m-%d)
+VERSIONSTRING	= $(APP) ($(REVISION) $(DATE)) $(OSNAME) $(ARCH)
 
 APP		 = $(shell echo "$(REPO)" | sed -e 's/_/-/g')
 # Assumes CURDIR is .../$(APP)/package/$(APP)/

--- a/package/deb/Makefile
+++ b/package/deb/Makefile
@@ -10,6 +10,7 @@ build:  $(BUILDPATH)/debian \
 	        --prepend-path=$(ERLANG_BIN) \
 		-e REVISION=$(REVISION) \
 		-e RELEASE=$(RELEASE) \
+		-e VERSIONSTRING="$(VERSIONSTRING)" \
 		-uc -us
 	mkdir -p packages
 	mv debuild/$(APP)_$(REVISION)-$(RELEASE)_*.deb packages

--- a/package/deb/rules
+++ b/package/deb/rules
@@ -17,6 +17,8 @@ LDFLAGS=
 
 build:
 	cp -f debian/vars.config rel/vars.config
+	cp rel/files/riak rel/files/riak.tmp
+	sed -e "s/^RIAK_VERSION.*$$/RIAK_VERSION=\"${VERSIONSTRING}\"/" < rel/files/riak.tmp > rel/files/riak && \
 	unset CC CFLAGS CPPFLAGS LDFLAGS CXX CXXFLAGS \
 		&& make rel
 	touch build

--- a/package/osx/Makefile
+++ b/package/osx/Makefile
@@ -1,4 +1,3 @@
-ARCH        = $(shell uname -m)
 PKGNAME     = $(APP)-$(REVISION)-osx-$(ARCH).tar.gz
 
 # simply tar up the rel directory and sha the file
@@ -15,7 +14,10 @@ build: buildrel
 
 # Build the release we need to package
 buildrel: $(BUILDDIR)/$(APP)-$(REVISION)
-	cd $^ && $(MAKE) deps compile rel
+	cd $^ && \
+	cp rel/files/riak rel/files/riak.tmp && \
+	sed -e "s/^RIAK_VERSION.*$$/RIAK_VERSION=\"${VERSIONSTRING}\"/" < rel/files/riak.tmp > rel/files/riak && \
+	$(MAKE) deps compile rel
 
 $(BUILDDIR)/$(APP)-$(REVISION): $(BUILDDIR) $(APP)-$(REVISION).tar.gz
 	tar xz -C $(BUILDDIR) -f $(APP)-$(REVISION).tar.gz

--- a/package/rpm/Makefile
+++ b/package/rpm/Makefile
@@ -16,6 +16,7 @@ build: $(PKGERDIR)/SOURCES/$(APP)-$(REVISION).tar.gz rpmbuild
 		 --define "_revision $(REVISION)" \
 		 --define "_version $(PKG_VERSION)" \
 		 --define "_release $(RELEASE)" \
+		 --define "_versionstring $(VERSIONSTRING)" \
 		 -ba $(PKGERDIR)/SPECS/$(APP).spec
 	cd packages && \
 		for rpmfile in `ls *.rpm`; do \

--- a/package/rpm/SPECS/riak.spec
+++ b/package/rpm/SPECS/riak.spec
@@ -69,6 +69,8 @@ cat > rel/vars.config <<EOF
 {pipe_dir,           "%{_localstatedir}/run/%{name}/"}.
 {runner_user,        "%{name}"}.
 EOF
+cp rel/files/riak rel/files/riak.tmp
+sed -e "s/^RIAK_VERSION.*$/RIAK_VERSION=\"%{_versionstring}\"/" < rel/files/riak.tmp > rel/files/riak
 
 %build
 mkdir %{name}

--- a/package/solaris/Makefile
+++ b/package/solaris/Makefile
@@ -1,7 +1,6 @@
 # requires GNU make
 PKG		 = BASHO$(APP)
 # possible ARCH values are i386, sparc, all
-ARCH		 = $(shell uname -p)
 SOLARIS_VER	?= $(shell echo "$(KERNEL)" | sed -e 's/^5\.//')
 PKGFILE		 = $(PKG)-$(REVISION)-$(RELEASE)-$(DISTRO)$(SOLARIS_VER)-$(ARCH).pkg
 
@@ -24,6 +23,8 @@ buildrel:
 	@# Make sure we set our EUID properly
 	echo "" >> $(RIAK_PATH)/rel/vars.config
 	echo '{runner_user, "riak"}.' >> $(RIAK_PATH)/rel/vars.config
+	cp $(RIAK_PATH)/rel/files/riak $(RIAK_PATH)/rel/files/riak.tmp
+	sed -e "s/^RIAK_VERSION.*$$/RIAK_VERSION=\"${VERSIONSTRING}\"/" < $(RIAK_PATH)/rel/files/riak.tmp > $(RIAK_PATH)/rel/files/riak
 	@# Ye Olde Bourne Shell on Solaris means we have to do it old school
 	echo "Using `which erl` to build"; \
 	$(MAKE) -C $(RIAK_PATH) deps rel

--- a/rebar.config
+++ b/rebar.config
@@ -10,8 +10,8 @@
 
 {deps, [
        {cluster_info, "1.2.0", {git, "git://github.com/basho/cluster_info", {tag, "1.2.0"}}},
-       {luwak, "1.1.*", {git, "git://github.com/basho/luwak", {branch, "1.1"}}},
-       {riak_kv, "1.0.*", {git, "git://github.com/basho/riak_kv", {branch, "1.0"}}},
-       {riak_search, "1.0.*", {git, "git://github.com/basho/riak_search",
-                                {branch, "1.0"}}}
+       {luwak, "1.1.1", {git, "git://github.com/basho/luwak", {tag, "1.1.1"}}},
+       {riak_kv, "1.0.1", {git, "git://github.com/basho/riak_kv", {tag, "1.0.1"}}},
+       {riak_search, "1.0.1", {git, "git://github.com/basho/riak_search",
+                                {tag, "1.0.1"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -9,9 +9,9 @@
 {erl_opts, [debug_info, fail_on_warning]}.
 
 {deps, [
-       {cluster_info, ".*", {git, "git://github.com/basho/cluster_info", {branch, "master"}}},
-       {luwak, ".*", {git, "git://github.com/basho/luwak", {branch, "master"}}},
-       {riak_kv, ".*", {git, "git://github.com/basho/riak_kv", {branch, "master"}}},
-       {riak_search, ".*", {git, "git://github.com/basho/riak_search",
-                                {branch, "master"}}}
+       {cluster_info, "1.2.0", {git, "git://github.com/basho/cluster_info", {tag, "1.2.0"}}},
+       {luwak, "1.1.*", {git, "git://github.com/basho/luwak", {branch, "1.1"}}},
+       {riak_kv, "1.0.*", {git, "git://github.com/basho/riak_kv", {branch, "1.0"}}},
+       {riak_search, "1.0.*", {git, "git://github.com/basho/riak_search",
+                                {branch, "1.0"}}}
        ]}.

--- a/rel/files/riak
+++ b/rel/files/riak
@@ -12,6 +12,7 @@ PIPE_DIR={{pipe_dir}}
 RUNNER_USER={{runner_user}}
 PLATFORM_DATA_DIR={{platform_data_dir}}
 SSL_DIST_CONFIG=$PLATFORM_DATA_DIR/ssl_distribution.args_file
+RIAK_VERSION="git"
 
 # Make sure this script is running as the appropriate user
 if [ "$RUNNER_USER" -a "x$LOGNAME" != "x$RUNNER_USER" ]; then
@@ -251,8 +252,11 @@ case "$1" in
         fi
         echo "config is OK"
         ;;
+    version)
+        echo $RIAK_VERSION
+        ;;
     *)
-        echo "Usage: $SCRIPT {start|stop|restart|reboot|ping|console|attach|chkconfig}"
+        echo "Usage: $SCRIPT {start|stop|restart|reboot|ping|console|attach|chkconfig|version}"
         exit 1
         ;;
 esac

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 {sys, [
        {lib_dirs, ["../deps", "../deps/riak_search/apps"]},
-       {rel, "riak", "1.0.0",
+       {rel, "riak", "1.0.1",
         [
          kernel,
          stdlib,


### PR DESCRIPTION
At package build time, capture info about when the package was built, what version it is, when it was built and what OS it was built for. Then expose that information in a machine and human parsable format via 'riak version'
