### PR TITLE
Fix init script (/var/run/riak, status, start)

### DIFF
--- a/package/rpm/SOURCES/riak_init
+++ b/package/rpm/SOURCES/riak_init
@@ -33,7 +33,7 @@ DAEMON=/usr/sbin/$NAME
 
 start() {
         #Check if Riak is running
-        RETVAL=`$DAEMON ping`
+	RETVAL=`su - riak -c "$DAEMON ping"`
         [ "$RETVAL" = "pong" ] && echo "Riak is already running" && return 1
 
 	# Start daemons.

--- a/package/rpm/SOURCES/riak_init
+++ b/package/rpm/SOURCES/riak_init
@@ -71,6 +71,12 @@ reload() {
 	return $RETVAL
 }
 
+status() {
+	RETVAL=`su - riak -c "$DAEMON ping"`
+	[ "$RETVAL" = "pong" ] && echo $"$NAME is running..." && return 0
+	echo $"$NAME is stopped"
+	return 3
+}
 
 # See how we were called.
 case "$1" in
@@ -86,6 +92,9 @@ case "$1" in
 	;;
   reload)
 	reload
+	;;
+  status)
+	status
 	;;
   ping)
 	su - riak -c "$DAEMON ping" || exit $?

--- a/package/rpm/SOURCES/riak_init
+++ b/package/rpm/SOURCES/riak_init
@@ -3,7 +3,7 @@
 # Riak Distributed Data Store
 #
 # chkconfig: 2345 80 30
-# description: Riak is a distrubuted data store.
+# description: Riak is a distributed data store.
 # processname: beam 
 # config: /etc/riak/app.config
 # config: /etc/riak/vm.args
@@ -16,7 +16,12 @@
 [ -x /usr/sbin/riak ] || exit 0
 [ -d /etc/riak ] || exit 0
 [ -d /var/lib/riak ] || exit 0
-[ -d /var/run/riak ] || exit 0
+
+# Create /var/run/riak if necessary (/var/run may be in a tmpfs filesystem).
+if [ ! -d /var/run/riak ]; then
+	mkdir -p /var/run/riak
+	chown riak:riak /var/run/riak
+fi
 
 RETVAL=0
 


### PR DESCRIPTION
This pull request fixes three small problems with riak's RPM init script:
1. On Fedora 15, /var/run is a tmpfs filesystem, and so the /var/run/riak directory goes away when the machine is rebooted. Change the init script to create it if it doesn't exist. This corresponds to bug 775 (https://issues.basho.com/show_bug.cgi?id=775) in the basho bugzilla.
2. Add a "status" command.
3. The "start" command incorrectly detects that riak is not running even if it is.
