### PR TITLE
enable mapred_2i_pipe by default on master (post-1.0)

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -74,6 +74,13 @@
             %% will be used
             {mapred_system, pipe},
 
+            %% mapred_2i_pipe indicates whether secondary-index
+            %% MapReduce inputs are queued in parallel via their own
+            %% pipe ('true'), or serially via a helper process
+            %% ('false' or undefined).  Set to 'false' or leave
+            %% undefined during a rolling upgrade from 1.0.
+            {mapred_2i_pipe, true},
+
             %% directory used to store a transient queue for pending
             %% map tasks
             %% Only valid when mapred_system == legacy


### PR DESCRIPTION
Enable the 2i-mapred-input feature implemented in https://github.com/basho/riak_kv/pull/249
