### PR TITLE
added support for 'status' command in the riak_init script

### DIFF
--- a/package/rpm/SOURCES/riak_init
+++ b/package/rpm/SOURCES/riak_init
@@ -82,11 +82,11 @@ case "$1" in
   reload)
 	reload
 	;;
-  ping)
+  ping|status)
 	su - riak -c "$DAEMON ping" || exit $?
         ;;
   *)
-	echo $"Usage: $0 {start|stop|reload|restart|ping}"
+	echo $"Usage: $0 {start|stop|reload|restart|ping|status}"
 	exit 1
 esac
 


### PR DESCRIPTION
added support for 'status' command in the riak_init script by aliasing status to ping.  This allows riak to be controlled more easily by puppet whose `service` provider expects init scripts to respond to a status command.
