### PR TITLE
AZ 1018: fix busy_dist_port monitoring

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -237,12 +237,17 @@
          %% To disable forwarding events of a particular type, use a
          %% limit of 0.
          {process_limit, 30},
-         {port_limit, 30},
+         {port_limit, 2},
 
          %% Finding reasonable limits for a given workload is a matter
          %% of experimentation.
-         {gc_ms_limit, 50},
-         {heap_word_limit, 10485760}
+         {gc_ms_limit, 100},
+         {heap_word_limit, 40111000},
+
+         %% Configure the following items to 'false' to disable logging
+         %% of that event type.
+         {busy_port, true},
+         {busy_dist_port, true}
         ]},
 
  %% SASL config


### PR DESCRIPTION
Changes to the `riak_sysmon` section of app.config:
- Reduce `port_limit` from 30 -> 2
- Double `gc_ms_limit` to 100 milliseconds
- Quadruple `heap_word_limit` to about 40M
- Add `true` entries for `busy_port` and `busy_dist_port`
