### PR TITLE
Enable new listkeys backpressure for new clusters, by default

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -145,7 +145,14 @@
             %% a version > 0.14 is completed for a cluster, this should be
             %% set to false for improved performance for bucket and key
             %% listing operations.
-            {legacy_keylisting, false}
+            {legacy_keylisting, false},
+
+            %% This option toggles compatibility of keylisting with 1.0
+            %% and earlier versions.  Once a rolling upgrade to a version
+            %% > 1.0 is completed for a cluster, this should be set to
+            %% true for better control of memory usage during key listing
+            %% operations
+            {listkeys_backpressure, true}
            ]},
 
  %% Riak Search Config


### PR DESCRIPTION
If https://github.com/basho/riak_kv/pull/263 is accepted, this patch will enable the new behavior by default.
