### PR TITLE
data_root_2i is not used. Let's remove it to reduce confusion.

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -166,9 +166,6 @@
                 %% The root dir to store search merge_index data
                 {data_root, "{{merge_index_data_root}}"},
 
-                %% The root dir to store secondary index merge_index data
-                {data_root_2i, "{{merge_index_data_root_2i}}"},
-
                 %% Size, in bytes, of the in-memory buffer.  When this
                 %% threshold has been reached the data is transformed
                 %% into a segment file which resides on disk.

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -26,9 +26,6 @@
 %% riak_search
 {merge_index_data_root,  "{{platform_data_dir}}/merge_index"}.
 
-%% secondary indices
-{merge_index_data_root_2i,  "{{platform_data_dir}}/merge_index_2i"}.
-
 %% Javascript VMs
 {map_js_vms,   8}.
 {reduce_js_vms, 6}.

--- a/rel/vars/dev1_vars.config
+++ b/rel/vars/dev1_vars.config
@@ -23,7 +23,6 @@
 {sasl_log_dir,      "{{platform_log_dir}}/sasl"}.
 {mapred_queue_dir,  "{{platform_data_dir}}/mr_queue"}.
 {merge_index_data_root,  "{{platform_data_dir}}/merge_index"}.
-{merge_index_data_root_2i,  "{{platform_data_dir}}/merge_index_2i"}.
 
 %% Javascript VMs
 {map_js_vms,   8}.

--- a/rel/vars/dev2_vars.config
+++ b/rel/vars/dev2_vars.config
@@ -23,7 +23,6 @@
 {sasl_log_dir,      "{{platform_log_dir}}/sasl"}.
 {mapred_queue_dir,  "{{platform_data_dir}}/mr_queue"}.
 {merge_index_data_root,  "{{platform_data_dir}}/merge_index"}.
-{merge_index_data_root_2i,  "{{platform_data_dir}}/merge_index_2i"}.
 
 %% Javascript VMs
 {map_js_vms,   8}.

--- a/rel/vars/dev3_vars.config
+++ b/rel/vars/dev3_vars.config
@@ -23,7 +23,6 @@
 {sasl_log_dir,      "{{platform_log_dir}}/sasl"}.
 {mapred_queue_dir,  "{{platform_data_dir}}/mr_queue"}.
 {merge_index_data_root,  "{{platform_data_dir}}/merge_index"}.
-{merge_index_data_root_2i,  "{{platform_data_dir}}/merge_index_2i"}.
 
 %% Javascript VMs
 {map_js_vms,   8}.

--- a/rel/vars/dev4_vars.config
+++ b/rel/vars/dev4_vars.config
@@ -23,7 +23,6 @@
 {sasl_log_dir,      "{{platform_log_dir}}/sasl"}.
 {mapred_queue_dir,  "{{platform_data_dir}}/mr_queue"}.
 {merge_index_data_root,  "{{platform_data_dir}}/merge_index"}.
-{merge_index_data_root_2i,  "{{platform_data_dir}}/merge_index_2i"}.
 
 %% Javascript VMs
 {map_js_vms,   8}.


### PR DESCRIPTION
Not sure why this is still around.
