### PR TITLE
Fix eunit testing so that passing tests don't cause make to fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,14 @@ testclean:
 # Test each dependency individually in its own VM
 test: deps compile testclean
 	@$(foreach dep, \
-                $(wildcard deps/*), \
-                    ./rebar eunit app=$(notdir $(dep)) \
-                        || echo "Eunit: $(notdir $(dep)) FAILED" >> $(TEST_LOG_FILE);)	
+            $(wildcard deps/*), \
+                ./rebar eunit app=$(notdir $(dep)) \
+                    || echo "Eunit: $(notdir $(dep)) FAILED" >> $(TEST_LOG_FILE);)	
 	./rebar eunit skip_deps=true
-	@test -s $(TEST_LOG_FILE) && cat $(TEST_LOG_FILE)
-	@exit `wc -l < $(TEST_LOG_FILE)`
+	@if test -s $(TEST_LOG_FILE) ; then \
+             cat $(TEST_LOG_FILE) && \
+             exit `wc -l < $(TEST_LOG_FILE)`; \
+        fi
 
 ##
 ## Release targets


### PR DESCRIPTION
When all tests pass, there is no eunit.log and that was causing 'test -s' to exit with return 1.   This just wraps that all in an if clause.
