### PR TITLE
vsn.git files are required for all deps when removing .git directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ build_clean_dir = cd distdir/$(CLONEDIR) && \
                   for dep in deps/*; do \
                       cd $${dep} && \
                       $(call archive_git,$${dep},../../../$(DISTNAME)) && \
-                      mkdir -p ../../../$(DISTNAME)/$${dep}}/priv && \
+                      mkdir -p ../../../$(DISTNAME)/$${dep}/priv && \
                       git describe --tags > ../../../$(DISTNAME)/$${dep}/priv/vsn.git && \
                       cd ../..; done
 

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,9 @@ DISTNAME = $(REPO)-$(MAJOR_VERSION)-$(NAME_HASH)
 endif
 
 # To ensure a clean build, copy the CLONEDIR at a specific tag to a new directory
-# which will be the basis of the src tar file (and packages)
+#  which will be the basis of the src tar file (and packages)
+# The vsn.git file is required by rebar to be able to build from the resulting
+#  tar file
 build_clean_dir = cd distdir/$(CLONEDIR) && \
                   $(call archive_git,$(DISTNAME),..) && \
                   cp $(MANIFEST_FILE) ../$(DISTNAME)/ && \
@@ -176,6 +178,8 @@ build_clean_dir = cd distdir/$(CLONEDIR) && \
                   for dep in deps/*; do \
                       cd $${dep} && \
                       $(call archive_git,$${dep},../../../$(DISTNAME)) && \
+                      mkdir -p ../../../$(DISTNAME)/$${dep}}/priv && \
+                      git describe --tags > ../../../$(DISTNAME)/$${dep}/priv/vsn.git && \
                       cd ../..; done
 
 


### PR DESCRIPTION
1.1 RC1 had an issue when trying to build from the release tarball.   Rebar checks for .git directories, and when those are not found it looks for vsn.git files instead to find the tag.   

This file was deleted prior to 1.1 because all tags were collected into a single file.  Now both the single file and each dependency file is created.
