### PR TITLE
Add config option to enable/disable tcp_nodelay on PB socket

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -60,6 +60,12 @@
             %% higher.
             %% {pb_backlog, 64},
 
+            %% disable_pb_nagle configures the use of tcp_nodelay on
+            %% the PB socket. By default tcp_nodelay is
+            %% true. Uncomment and set to false to disable tcp_nodelay
+            %% on the PB socket.
+            %% {disable_pb_nagle, true},
+
             %% raw_name is the first part of all URLS used by the Riak raw HTTP
             %% interface.  See riak_web.erl and raw_http_resource.erl for
             %% details.


### PR DESCRIPTION
Already merged the riak_kv PR that uses this (riak_kv/#102)
