### PR TITLE
Add {legacy_vnode_routing, false} to default app.config.

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -31,6 +31,10 @@
               %% single file with both items concatenated together.)
               %{handoff_ssl_options, [{certfile, "/tmp/erlserver.pem"}]},
 
+              %% Disable legacy vnode routing for 1.1.x and above clusters
+              %% (use vnode proxies).  Only set true on mixed clusters.
+              {legacy_vnode_routing, false},
+
               %% Platform-specific installation paths (substituted by rebar)
               {platform_bin_dir, "{{platform_bin_dir}}"},
               {platform_data_dir, "{{platform_data_dir}}"},


### PR DESCRIPTION
Set default correctly for new installs.
