### PR TITLE
Extract Protocol Buffers interface from KV

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -1,6 +1,24 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ft=erlang ts=4 sw=4 et
 [
+ %% Riak Client APIs config
+ {riak_api, [
+            %% pb_backlog is the maximum length to which the queue of pending
+            %% connections may grow. If set, it must be an integer >= 0.
+            %% By default the value is 5. If you anticipate a huge number of
+            %% connections being initialised *simultaneously*, set this number
+            %% higher.
+            %% {pb_backlog, 64},
+
+            %% pb_ip is the IP address that the Riak Protocol Buffers interface
+            %% will bind to.  If this is undefined, the interface will not run.
+            {pb_ip,   "{{pb_ip}}" },
+
+            %% pb_port is the TCP port that the Riak Protocol Buffers interface
+            %% will bind to
+            {pb_port, {{pb_port}} }
+            ]},
+
  %% Riak Core config
  {riak_core, [
               %% Default location of ringstate
@@ -48,21 +66,6 @@
             %% Storage_backend specifies the Erlang module defining the storage
             %% mechanism that will be used on this node.
             {storage_backend, riak_kv_bitcask_backend},
-
-            %% pb_ip is the IP address that the Riak Protocol Buffers interface
-            %% will bind to.  If this is undefined, the interface will not run.
-            {pb_ip,   "{{pb_ip}}" },
-
-            %% pb_port is the TCP port that the Riak Protocol Buffers interface
-            %% will bind to
-            {pb_port, {{pb_port}} },
-
-            %% pb_backlog is the maximum length to which the queue of pending
-            %% connections may grow. If set, it must be an integer >= 0.
-            %% By default the value is 5. If you anticipate a huge number of
-            %% connections being initialised *simultaneously*, set this number
-            %% higher.
-            %% {pb_backlog, 64},
 
             %% raw_name is the first part of all URLS used by the Riak raw HTTP
             %% interface.  See riak_web.erl and raw_http_resource.erl for

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -26,7 +26,8 @@
          cluster_info,
          lager,
          basho_metrics,
-         riak_control
+         riak_control,
+         riak_api
         ]},
        {rel, "start_clean", "",
         [
@@ -51,7 +52,8 @@
        {app, sasl, [{incl_cond, include}]},
        {app, lager, [{incl_cond, include}]},
        {app, basho_metrics, [{incl_cond, include}]},
-       {app, riak_control, [{incl_cond, include}]}
+       {app, riak_control, [{incl_cond, include}]},
+       {app, riak_api, [{incl_cond, include}]}
       ]}.
 
 


### PR DESCRIPTION
This is part of a series of pull-requests to extract the Protocol Buffers interface from `riak_kv` and make it available to all applications in an unobtrusive manner.

Related: basho/riak_kv#321

This specific pull-request adjusts app.config to move settings into the new `riak_api`, enables R15B01 support, and temporarily points the `riak_kv` dependency at the branch that includes the refactoring.

The Java and Python clients test suites should pass against this refactoring. Ruby and Erlang clients test suites fail because they directly modify the server or its configuration. Manual testing and benchmarking is encouraged.
