### PR TITLE
Remove bashisms from shell scripts which use /bin/sh

### DIFF
--- a/rel/files/riak
+++ b/rel/files/riak
@@ -26,7 +26,7 @@ RIAK_VERSION="git"
 
 # Make sure this script is running as the appropriate user
 if [ "$RUNNER_USER" -a "x$LOGNAME" != "x$RUNNER_USER" ]; then
-    type -p sudo > /dev/null 2>&1
+    type sudo > /dev/null 2>&1
     if [ $? -ne 0 ]; then
         echo "sudo doesn't appear to be installed and your EUID isn't $RUNNER_USER" 1>&2
         exit 1
@@ -171,7 +171,7 @@ case "$1" in
         if [ "$ES" -ne 0 ]; then
             exit $ES
         fi
-        while `kill -0 $PID 2>/dev/null`;
+        while `kill -s 0 $PID 2>/dev/null`;
         do
             sleep 1
         done

--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -19,7 +19,7 @@ RUNNER_USER={{runner_user}}
 
 # Make sure this script is running as the appropriate user
 if [ "$RUNNER_USER" -a "x$LOGNAME" != "x$RUNNER_USER" ]; then
-    type -p sudo > /dev/null 2>&1
+    type sudo > /dev/null 2>&1
     if [ $? -ne 0 ]; then
         echo "sudo doesn't appear to be installed and your EUID isn't $RUNNER_USER" 1>&2
         exit 1

--- a/rel/files/search-cmd
+++ b/rel/files/search-cmd
@@ -19,7 +19,7 @@ RUNNER_USER={{runner_user}}
 
 # Make sure this script is running as the appropriate user
 if [ "$RUNNER_USER" -a "x$LOGNAME" != "x$RUNNER_USER" ]; then
-    type -p sudo > /dev/null 2>&1
+    type sudo > /dev/null 2>&1
     if [ $? -ne 0 ]; then
         echo "sudo doesn't appear to be installed and your EUID isn't $RUNNER_USER" 1>&2
         exit 1


### PR DESCRIPTION
Fixes #140

`type -p` is not supported by /bin/sh and caused the riak and riak-admin scripts
to think that `sudo` was not available.  In addition `kill -SIGNAL` is not portable
to /bin/sh and should be replaced by `kill -s SIGNAL` instead.

The portability was checked with `checkbashisms` from the devscripts package in
ubuntu 10.04 and was tested on /bin/sh in solaris, ubuntu, and OSX.
