### PR TITLE
Remove default support for OpenSolaris

### DIFF
--- a/package/Makefile
+++ b/package/Makefile
@@ -19,7 +19,7 @@ ARCH		= $(shell uname -p)
 PKGER		= make
 PKGERDIR	= solaris
 DISTRO		= $(shell head -1 /etc/release|awk \
-                   '{if ($$1 == "OpenSolaris") {print $$1} else {print "Solaris"}}')
+                   '{if ($$1 == "OmniOS") {print $$1} else {print "Solaris"}}')
 OSNAME		= ${DISTRO}
 endif
 ifeq ($(OS),Darwin)
@@ -36,7 +36,7 @@ VERSIONSTRING	= $(APP) ($(PKG_VERSION) $(DATE)) $(OSNAME) $(ARCH)
 APP		 = $(shell echo "$(REPO)" | sed -e 's/_/-/g')
 # Assumes CURDIR is .../$(APP)/package/$(APP)/
 RIAK_PATH	?= ..
-RELEASE		?= 
+RELEASE		?=
 
 $(APP)-$(PKG_VERSION).tar.gz: ../$(DISTNAME).tar.gz
 	ln -s $< $@

--- a/package/solaris/Makefile
+++ b/package/solaris/Makefile
@@ -9,7 +9,7 @@ build: buildrel depend pkginfo prototype
 	mkdir -p pkgbuild packages
 	pkgmk -o -d pkgbuild -a $(ARCH)
 	touch packages/$(PKGFILE)
-	pkgtrans -s pkgbuild packages/$(PKGFILE) $(PKG) 
+	pkgtrans -s pkgbuild packages/$(PKGFILE) $(PKG)
 	rm -r pkgbuild/$(PKG)
 	gzip packages/$(PKGFILE)
 	chmod 0644 $(CURDIR)/packages/$(PKGFILE).gz
@@ -33,9 +33,6 @@ buildrel:
 
 depend:
 	cp $(PKGERDIR)/depend .
-	if [ $(DISTRO) = "OpenSolaris" ]; then \
-		echo "P SUNWgawk   GNU implementation of awk" >> depend; \
-	fi
 
 pkginfo:
 	sed -e 's/@@VERSION@@/$(PKG_VERSION)-$(RELEASE)/g' \


### PR DESCRIPTION
OpenSolaris no longer exists as it did when support was added for it. In addition, OmniOS added support
for RIak with the simple patch of s/OpenSolaris/OmniOS/ in the package/Makefile. The OmniOS packages
will still be generated by the OmniOS team, but adding that string to the makefile makes it one step easier for
them to build Riak and that is a Good Thing (tm).
