### PR TITLE
Make `ring_creation_size` setting for riak_core more obvious and available

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -6,6 +6,10 @@
               %% Default location of ringstate
               {ring_state_dir, "{{ring_state_dir}}"},
 
+              %% Default ring creation size.  Make sure it is a power of 2,
+              %% e.g. 16, 32, 64, 128, 256, 512 etc
+              %{ring_creation_size, 64},
+
               %% http is a list of IP addresses and TCP ports that the Riak
               %% HTTP interface will bind.
               {http, [ {"{{web_ip}}", {{web_port}} } ]},


### PR DESCRIPTION
Fixes #139
