### PR TITLE
Move the pipe_dir on fedora/centos to the /tmp/riak directory.

### DIFF
--- a/package/rpm/SOURCES/riak_init
+++ b/package/rpm/SOURCES/riak_init
@@ -4,7 +4,7 @@
 #
 # chkconfig: 2345 80 30
 # description: Riak is a distributed data store.
-# processname: beam 
+# processname: beam
 # config: /etc/riak/app.config
 # config: /etc/riak/vm.args
 #
@@ -17,10 +17,10 @@
 [ -d /etc/riak ] || exit 0
 [ -d /var/lib/riak ] || exit 0
 
-# Create /var/run/riak if necessary (/var/run may be in a tmpfs filesystem).
-if [ ! -d /var/run/riak ]; then
-    mkdir -p /var/run/riak
-    chown riak:riak /var/run/riak
+# Create /tmp/riak if necessary
+if [ ! -d /tmp/riak ]; then
+    mkdir -p /tmp/riak
+    chown riak:riak /tmp/riak
 fi
 
 RETVAL=0
@@ -49,7 +49,7 @@ stop() {
     # Stop daemon.
     echo -n $"Stopping Riak: "
     RETVAL=`su - riak -c "$DAEMON ping"`
-    [ "$RETVAL" = "pong" ] && su - riak -c "$DAEMON stop 2>/dev/null 1>&2" 
+    [ "$RETVAL" = "pong" ] && su - riak -c "$DAEMON stop 2>/dev/null 1>&2"
     sleep 2
     RETVAL=`pidof beam.smp`
     [ "$RETVAL" = "" ] && success && echo && return 0 || failure $"$NAME stop"
@@ -65,7 +65,7 @@ reload() {
     echo -n $"Reloading Riak: "
     RETVAL=`su - riak -c "$DAEMON ping"`
     [ "$RETVAL" = "pong" ] && su - riak -c "$DAEMON restart 2>/dev/null 1>&2" \
-        && success && echo && return 0 || failure $"$NAME restart" 
+        && success && echo && return 0 || failure $"$NAME restart"
     echo
     return $RETVAL
 }
@@ -84,23 +84,23 @@ case "$1" in
         ;;
   stop)
         stop
-	;;
+        ;;
   restart)
         stop
-	start
-	;;
+        start
+        ;;
   reload)
-	reload
-	;;
+        reload
+        ;;
   status)
-	status
-	;;
+        status
+        ;;
   ping)
         su - riak -c "$DAEMON ping" || exit $?
         ;;
   *)
         echo $"Usage: $0 {start|stop|reload|restart|ping}"
-	exit 1
+        exit 1
 esac
 
 exit $?

--- a/package/rpm/SPECS/riak.spec
+++ b/package/rpm/SPECS/riak.spec
@@ -83,7 +83,7 @@ cat > rel/vars.config <<EOF
 {runner_base_dir,    "%{platform_lib_dir}"}.
 {runner_etc_dir,     "%{platform_etc_dir}"}.
 {runner_log_dir,     "%{platform_log_dir}"}.
-{pipe_dir,           "%{_localstatedir}/run/%{name}/"}.
+{pipe_dir,           "/tmp/%{name}/"}.
 {runner_user,        "%{name}"}.
 EOF
 


### PR DESCRIPTION
Fixes: #130

On newer fedora systems, `/var/run` became a tmpfs.
On reboot, `/var/run/riak` would be deleted and the `riak`
user would not have rights to create a new directory in
`/var/run`.  The pipe_dir is now moved to `/tmp/riak` much
like it has been on debian based systems since the beginning.
