### PR TITLE
Treatment for commented lines in node.args

### DIFF
--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -32,7 +32,7 @@ fi
 cd $RUNNER_BASE_DIR
 
 # Extract the target node name from node.args
-NAME_ARG=`grep '\-[s]*name' $RUNNER_ETC_DIR/vm.args`
+NAME_ARG=`grep -v ^# $RUNNER_ETC_DIR/vm.args | grep '\-[s]*name'`
 if [ -z "$NAME_ARG" ]; then
     echo "vm.args needs to have either -name or -sname parameter."
     exit 1


### PR DESCRIPTION
Hi, I was getting an error using riak-admin commands, it was printing 

"Node is not running!"

So I took a day to discover that only the last line matched with "-name" was taken by riak-admin script, like "foobar@..." in this context

-name riak@10.32.218.65
# -name riak@127.0.0.1
# -name foobar@127.0.0.1

The patch removes out lines started with #.

Thx
