### PR TITLE
Add {dtrace_support, false} to app.config

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -56,8 +56,9 @@
               %% DTrace support
               %% Do not enable 'dtrace_support' unless your Erlang/OTP
               %% runtime is compiled to support DTrace.  DTrace is
-              %% available in R15B01 and in R14B04 via a source branch
-              %% unsupported by the Erlang/OTP team.
+              %% available in R15B01 (supported by the Erlang/OTP
+              %% official source package) and in R14B04 via a custom
+              %% source repository & branch.
               {dtrace_support, false},
 
               %% Platform-specific installation paths (substituted by rebar)

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -53,6 +53,13 @@
               %% single file with both items concatenated together.)
               %{handoff_ssl_options, [{certfile, "/tmp/erlserver.pem"}]},
 
+              %% DTrace support
+              %% Do not enable 'dtrace_support' unless your Erlang/OTP
+              %% runtime is compiled to support DTrace.  DTrace is
+              %% available in R15B01 and in R14B04 via a source branch
+              %% unsupported by the Erlang/OTP team.
+              {dtrace_support, false},
+
               %% Platform-specific installation paths (substituted by rebar)
               {platform_bin_dir, "{{platform_bin_dir}}"},
               {platform_data_dir, "{{platform_data_dir}}"},


### PR DESCRIPTION
Add `dtrace_support` configuration knob to the default `app.config` file.

Default to `false` for safety: things don't go so well if the value is `true` and your Erlang/OTP runtime system doesn't support DTrace.
