### PR TITLE
Change ownership of /etc/riak for RPM packages

### DIFF
--- a/package/rpm/SPECS/riak.spec
+++ b/package/rpm/SPECS/riak.spec
@@ -157,11 +157,11 @@ find %{platform_lib_dir} -name "*.so" -exec chcon -t textrel_shlib_t {} \;
 %{_libdir}/*
 %dir %{platform_etc_dir}
 %config(noreplace) %{platform_etc_dir}/*
-%attr(0755,-,-) %{init_script}
-%attr(0755,-,-) %{platform_bin_dir}/%{name}
-%attr(0755,-,-) %{platform_bin_dir}/%{name}-admin
-%attr(0755,-,-) %{platform_bin_dir}/search-cmd
-%attr(0644,-,-) %{_mandir}/man1/*
+%{init_script}
+%{platform_bin_dir}/%{name}
+%{platform_bin_dir}/%{name}-admin
+%{platform_bin_dir}/search-cmd
+%{_mandir}/man1/*
 %attr(-,riak,riak) %{platform_data_dir}
 %attr(-,riak,riak) %{platform_log_dir}
 

--- a/package/rpm/SPECS/riak.spec
+++ b/package/rpm/SPECS/riak.spec
@@ -153,17 +153,17 @@ fi
 find %{platform_lib_dir} -name "*.so" -exec chcon -t textrel_shlib_t {} \;
 
 %files
-%defattr(-,riak,riak)
-%attr(-,root,root) %{_libdir}/*
+%defattr(-,root,root)
+%{_libdir}/*
 %dir %{platform_etc_dir}
 %config(noreplace) %{platform_etc_dir}/*
-%attr(0755,root,root) %{init_script}
-%attr(0755,root,root) %{platform_bin_dir}/%{name}
-%attr(0755,root,root) %{platform_bin_dir}/%{name}-admin
-%attr(0755,root,root) %{platform_bin_dir}/search-cmd
-%attr(0644,root,root) %{_mandir}/man1/*
-%{platform_data_dir}
-%{platform_log_dir}
+%attr(0755,-,-) %{init_script}
+%attr(0755,-,-) %{platform_bin_dir}/%{name}
+%attr(0755,-,-) %{platform_bin_dir}/%{name}-admin
+%attr(0755,-,-) %{platform_bin_dir}/search-cmd
+%attr(0644,-,-) %{_mandir}/man1/*
+%attr(-,riak,riak) %{platform_data_dir}
+%attr(-,riak,riak) %{platform_log_dir}
 
 %clean
 rm -rf %{buildroot}


### PR DESCRIPTION
The current RPM packages set the ownership of `/etc/riak` and the configurations files therein to `riak:riak`. This is typically considered bad practice because the daemon shouldn't have, or need, permissions to modify it's own configs.

The first commit in this PR rectifies that. The default file ownership is set to `root:root` and log/state directories are then explicitly owned to `riak:riak`. This matches the behaviour of the Debian packages.

The second commit omits some attributes that already come from the `%install` section, thus simplifying the SPEC. It could be squashed into the prior commit if preferred.
