### PR TITLE
Depend on 'sudo' package in RPM package

### DIFF
--- a/package/rpm/SPECS/riak.spec
+++ b/package/rpm/SPECS/riak.spec
@@ -17,6 +17,8 @@ Packager: Basho Technologies <riak-user@lists.basho.com>
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 Summary: Riak Distributed Data Store
 
+requires: sudo
+
 %description
 Riak is a highly scalable, fault-tolerant distributed database
 


### PR DESCRIPTION
Fixes #163

Reference page: http://www.rpm.org/max-rpm/s1-rpm-depend-manual-dependencies.html

Result of query of the package after building from this branch

``` shell
(sandbox)[buildbot@build-centos-6-64 packages]$ rpm -qpR riak-1.2.0pre2.dfc7de74-1.el6.x86_64.rpm
/bin/bash  
/bin/sh  
/bin/sh  
/bin/sh  
/usr/bin/env  
config(riak) = 1.2.0pre2.dfc7de74-1.el6
libc.so.6()(64bit)  
libc.so.6(GLIBC_2.2.5)(64bit)  
libc.so.6(GLIBC_2.3)(64bit)  
libc.so.6(GLIBC_2.3.2)(64bit)  
libc.so.6(GLIBC_2.3.4)(64bit)  
libcrypto.so.10()(64bit)  
libdl.so.2()(64bit)  
libdl.so.2(GLIBC_2.2.5)(64bit)  
libgcc_s.so.1()(64bit)  
libgcc_s.so.1(GCC_3.0)(64bit)  
libm.so.6()(64bit)  
libm.so.6(GLIBC_2.2.5)(64bit)  
libncurses.so.5()(64bit)  
libpthread.so.0()(64bit)  
libpthread.so.0(GLIBC_2.2.5)(64bit)  
libpthread.so.0(GLIBC_2.3.2)(64bit)  
librt.so.1()(64bit)  
librt.so.1(GLIBC_2.2.5)(64bit)  
libssl.so.10()(64bit)  
libstdc++.so.6()(64bit)  
libstdc++.so.6(CXXABI_1.3)(64bit)  
libstdc++.so.6(GLIBCXX_3.4)(64bit)  
libtinfo.so.5()(64bit)  
libutil.so.1()(64bit)  
libutil.so.1(GLIBC_2.2.5)(64bit)  
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rtld(GNU_HASH)  
sudo  
rpmlib(PayloadIsXz) <= 5.2-1
(sandbox)[buildbot@build-centos-6-64 packages]$ 
```
