### PR TITLE
Add a pkgdep and origin line to the freebsd package to fix install errors

### DIFF
--- a/package/freebsd/Makefile
+++ b/package/freebsd/Makefile
@@ -26,6 +26,8 @@ packing_list: $(BUILD_STAGE_DIR)
 	echo "@exec if ! pw usershow riak 2>/dev/null; then pw useradd riak -g riak -h - -d /usr/local/riak -s /bin/sh -c \"Riak Server\"; fi" >> plist
 	echo "@owner riak" >> plist
 	echo "@group riak" >> plist
+	echo "@pkgdep openssl-1.0.0_7" >> plist
+	echo "@comment ORIGIN:basho/riak" >> plist
 	mv plist $(BUILD_STAGE_DIR)/+CONTENTS
 	cd $(BUILD_STAGE_DIR) && \
            find riak -type f >> +CONTENTS
@@ -42,7 +44,7 @@ templates: $(BUILD_STAGE_DIR)
            $(PKGERDIR)/+MTREE_DIRS $(PKGERDIR)/+DISPLAY \
            $(BUILD_STAGE_DIR)
 
-# Copy the app rel directory to the staging directory to build our 
+# Copy the app rel directory to the staging directory to build our
 # package structure
 $(BUILD_STAGE_DIR): buildrel
 	@echo "Copying rel directory to staging directory"


### PR DESCRIPTION
# Openssl

Riak depends on openssl, but openssl is not installed by default on a base
FreeBSD 9 machine.  This adds a `@pkgdep` line to require openssl.

Fixes basho/riak#171
# ORIGIN warnings

If an ORIGIN comment is not found, all new package installs and deletes
will comment on riak not having an origin recorded.

Fixes basho/riak#167
## With old Riak package installed

``` shell
jameson% sudo pkg_delete wget-1.13.4_1 
pkg_delete: package riak-1.2.0pre3 has no origin recorded
```
## With new Riak package installed

``` shell
jameson% sudo pkg_delete wget-1.13.4_1 
jameson% sudo pkg_add -r wget
Fetching ftp://ftp.freebsd.org/pub/FreeBSD/ports/amd64/packages-9.0-release/Latest/wget.tbz... Done.
```
