### PR TITLE
Change regex to allow commented out -name lines

### DIFF
--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -37,7 +37,7 @@ fi
 cd $RUNNER_BASE_DIR
 
 # Extract the target node name from node.args
-NAME_ARG=`grep '\-[s]*name' $RUNNER_ETC_DIR/vm.args`
+NAME_ARG=`grep "^[[:space:]]*-s\?name" $RUNNER_ETC_DIR/vm.args`
 if [ -z "$NAME_ARG" ]; then
     echo "vm.args needs to have either -name or -sname parameter."
     exit 1

--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -37,7 +37,7 @@ fi
 cd $RUNNER_BASE_DIR
 
 # Extract the target node name from node.args
-NAME_ARG=`grep "^[[:space:]]*-s\?name" $RUNNER_ETC_DIR/vm.args`
+NAME_ARG=`egrep "^ *-s?name" $RUNNER_ETC_DIR/vm.args`
 if [ -z "$NAME_ARG" ]; then
     echo "vm.args needs to have either -name or -sname parameter."
     exit 1


### PR DESCRIPTION
The regex should ignore vm.args lines like the following:
# -name riak@127.0.0.1
# -name test-riak@node.hode
# use the -name switch to specify the name of the node

-administrator-name admin
-sssssssssname foo
