### PR TITLE
Fix permissions on Freebsd and SmartOS package install directories

### DIFF
--- a/package/freebsd/Makefile
+++ b/package/freebsd/Makefile
@@ -65,6 +65,7 @@ packing_list_files: $(BUILD_STAGE_DIR)
 	cd $(BUILD_STAGE_DIR) && \
 	   echo "@owner root" >> +CONTENTS && \
 	   echo "@group wheel" >> +CONTENTS && \
+	   echo "@mode 0644" >> +CONTENTS && \
 	   find etc -type f >> +CONTENTS && \
 	   find etc -d -type d -exec echo "@dirrm {}" \; >> +CONTENTS
 
@@ -77,11 +78,13 @@ packing_list_files: $(BUILD_STAGE_DIR)
 	cd $(BUILD_STAGE_DIR) && \
 	   find db -type f >> +CONTENTS && \
            find db -d -type d -exec echo "@dirrm {}" \; >> +CONTENTS && \
-	   echo "@exec chown -R riak:riak /var/db/riak" >> +CONTENTS
+	   echo "@exec chown -R riak:riak /var/db/riak" >> +CONTENTS && \
+	   echo "@exec chmod 700 /var/db/riak" >> +CONTENTS
 	cd $(BUILD_STAGE_DIR) && \
 	   find log -type f >> +CONTENTS && \
            find log -d -type d -exec echo "@dirrm {}" \; >> +CONTENTS && \
-	   echo "@exec chown -R riak:riak /var/log/riak" >> +CONTENTS
+	   echo "@exec chown -R riak:riak /var/log/riak" >> +CONTENTS && \
+	   echo "@exec chmod 700 /var/log/riak" >> +CONTENTS
 
 	cd $(BUILD_STAGE_DIR) && \
 	   echo "@display +DISPLAY" >> +CONTENTS

--- a/package/smartos/+INSTALL
+++ b/package/smartos/+INSTALL
@@ -19,9 +19,9 @@ fi
 # Create var directories outside of +CONTENTS
 mkdir -p ${RIAK_DATA_DIR}
 chown -R ${USER}:${USER} ${RIAK_DATA_DIR}
-chmod 770 ${RIAK_DATA_DIR}
+chmod 700 ${RIAK_DATA_DIR}
 mkdir -p ${RIAK_LOG_DIR}
 chown -R ${USER}:${USER} ${RIAK_LOG_DIR}
-chmod 770 ${RIAK_LOG_DIR}
+chmod 700 ${RIAK_LOG_DIR}
 
 exit 0

--- a/package/smartos/Makefile
+++ b/package/smartos/Makefile
@@ -67,7 +67,9 @@ packing_list_files: $(BUILD_STAGE_DIR) templates
 	   echo "@cwd /opt/local" >> +CONTENTS && \
 	   echo "@owner root" >> +CONTENTS && \
 	   echo "@group root" >> +CONTENTS && \
-	   find etc -type f >> +CONTENTS
+	   echo "@mode 0644" >> +CONTENTS && \
+	   find etc -type f >> +CONTENTS && \
+	   echo "@exec chown -R root:root /opt/local/etc/riak" >> +CONTENTS
 
 	cd $(BUILD_STAGE_DIR) && \
 	   echo "@cwd /opt/local" >> +CONTENTS && \
@@ -103,7 +105,7 @@ templates: $(BUILD_STAGE_DIR)
 # package structure and move the directories into the right place
 # for the package, see the vars.config file for destination
 # directories
-# The data and log directories need to go into /var, but the 
+# The data and log directories need to go into /var, but the
 # smartos pkg_add doesn't allow this to be in the +CONTENTS
 # file so the directories are created in the +INSTALL script
 $(BUILD_STAGE_DIR): buildrel


### PR DESCRIPTION
Fixes #180

Tested against FreeBSD with `riak` user and SmartOS using `svcadm`.

Both SmartOS and FreeBSD now have the following permissions:

`/var/db/riak` and `/var/log/riak` are chmod 0700 owned by riak:riak

the etc_dir (`/usr/local/etc/riak` on FreeBSD and `/opt/local/etc/riak`) are both have 0644 contents and owned by root:root (or root:wheel on freebsd).
