### PR TITLE
Ensure erlydtl is packaged.

### DIFF
--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -26,6 +26,7 @@
          cluster_info,
          lager,
          riak_control,
+         erlydtl,
          riak_api,
          folsom
         ]},


### PR DESCRIPTION
Related to new requirement in Riak Control for erlydtl.

https://github.com/basho/riak_control/pull/28
