### PR TITLE
Create SMF service for epmd on SmartOS

### DIFF
--- a/package/smartos/+DISPLAY
+++ b/package/smartos/+DISPLAY
@@ -22,9 +22,18 @@ Man pages are available for riak(1), riak-admin(1), and search-cmd(1)
 This package is SMF enabled, which means you can use SMF to 'enable',
 'disable' or 'restart' the persistent daemon process, e.g.:
 
-  svcadm enable riak
+  $ svcadm enable -r riak
 
-The SMF manifest was automatically imported now.
+Two SMF manifests were created, "riak-epmd" and "riak".  Riak depends
+on the "riak-epmd" service to be enabled, so either use "-r" to specify
+to "svcadm" (as shown above) to recursively start dependencies or
+start each service independent of each other.
+
+  $ svcadm enable riak-epmd
+  $ svcadm enable riak
+
+You should *NOT* stop or restart the "riak-epmd" service at any time,
+if you need to restart Riak, just restart the "riak" service.
 
 See the SmartOS wiki on what's SMF and how to use it to your advantage:
 

--- a/package/smartos/+INSTALL
+++ b/package/smartos/+INSTALL
@@ -1,27 +1,33 @@
 #!/bin/sh
 
-if [ "$2" != "PRE-INSTALL" ]; then
-    exit 0
-fi
-
 USER=riak
 RIAK_DATA_DIR=/var/db/riak
 RIAK_LOG_DIR=/var/log/riak
 
-if ! getent group "${USER}" 2>/dev/null 1>&2; then
-   groupadd ${USER}
+if [ "$2" = "PRE-INSTALL" ]; then
+    if ! getent group "${USER}" 2>/dev/null 1>&2; then
+        groupadd ${USER}
+    fi
+
+    if ! getent passwd "${USER}" 2>/dev/null 1>&2; then
+        useradd -g ${USER} -d /opt/local/lib/${USER} -s /bin/sh ${USER}
+    fi
+
+    # Create var directories outside of +CONTENTS
+    mkdir -p ${RIAK_DATA_DIR}
+    chown -R ${USER}:${USER} ${RIAK_DATA_DIR}
+    chmod 700 ${RIAK_DATA_DIR}
+    mkdir -p ${RIAK_LOG_DIR}
+    chmod 700 ${RIAK_LOG_DIR}
+    chown -R ${USER}:${USER} ${RIAK_LOG_DIR}
+
 fi
 
-if ! getent passwd "${USER}" 2>/dev/null 1>&2; then
-   useradd -g ${USER} -d /opt/local/lib/${USER} -s /bin/sh ${USER}
+if [ "$2" = "POST-INSTALL" ]; then
+    # Import SMF definitions
+    svccfg import /opt/local/share/smf/riak-epmd/manifest.xml
+    chmod 755 /opt/local/share/smf/riak-epmd/riak-epmd
+    svccfg import /opt/local/share/smf/riak/manifest.xml
 fi
-
-# Create var directories outside of +CONTENTS
-mkdir -p ${RIAK_DATA_DIR}
-chown -R ${USER}:${USER} ${RIAK_DATA_DIR}
-chmod 700 ${RIAK_DATA_DIR}
-mkdir -p ${RIAK_LOG_DIR}
-chown -R ${USER}:${USER} ${RIAK_LOG_DIR}
-chmod 700 ${RIAK_LOG_DIR}
 
 exit 0

--- a/package/smartos/Makefile
+++ b/package/smartos/Makefile
@@ -1,18 +1,23 @@
-BUILD_RIAK_PATH = $(BUILDDIR)/$(REPO)-$(PKG_VERSION)
-BUILD_STAGE_DIR = $(BUILDDIR)/$(APP)
+BUILD_RIAK_PATH := $(BUILDDIR)/$(REPO)-$(PKG_VERSION)
+BUILD_STAGE_DIR := $(BUILDDIR)/$(APP)
 
 # Where we install things (based on vars.config)
 # /opt/local based dirs
-PMAN_DIR         = $(BUILD_STAGE_DIR)/man
-PBIN_DIR         = $(BUILD_STAGE_DIR)/sbin
-PETC_DIR         = $(BUILD_STAGE_DIR)/etc/riak
-PLIB_DIR         = $(BUILD_STAGE_DIR)/lib/riak
-PSMF_DIR         = $(BUILD_STAGE_DIR)/share/smf/riak
+PMAN_DIR         := $(BUILD_STAGE_DIR)/man
+PBIN_DIR         := $(BUILD_STAGE_DIR)/sbin
+PETC_DIR         := $(BUILD_STAGE_DIR)/etc/riak
+PLIB_DIR         := $(BUILD_STAGE_DIR)/lib/riak
+PSMF_DIR         := $(BUILD_STAGE_DIR)/share/smf/riak
+ESMF_DIR         := $(BUILD_STAGE_DIR)/share/smf/riak-epmd
+
+# Recursive assignment of ERTS version
+# We will know this after building the rel
+ERTS_PATH        = $(shell ls $(BUILD_RIAK_PATH)/rel/riak | egrep -o "erts-.*")
 
 # /var based dirs are handled in the +INSTALL file
 
-TARNAME = $(APP)-$(PKG_VERSION)-$(OSNAME)-$(ARCH).tar
-PKGNAME = $(APP)-$(PKG_VERSION)-$(OSNAME)-$(ARCH).tgz
+TARNAME := $(APP)-$(PKG_VERSION)-$(OSNAME)-$(ARCH).tar
+PKGNAME := $(APP)-$(PKG_VERSION)-$(OSNAME)-$(ARCH).tgz
 
 # pkg_add on Smartos requires that the tar file
 # and +CONTENTS files are in the exact same order
@@ -101,6 +106,10 @@ templates: $(BUILD_STAGE_DIR)
 	   $(PKGERDIR)/+DISPLAY $(BUILD_STAGE_DIR)
 	mkdir -p $(PSMF_DIR)
 	cp $(PKGERDIR)/manifest.xml $(PSMF_DIR)
+	mkdir -p $(ESMF_DIR)
+	sed -e "s/%ERTS_PATH%/${ERTS_PATH}/" < \
+		$(PKGERDIR)/riak-epmd > $(ESMF_DIR)/riak-epmd
+	cp $(PKGERDIR)/epmd-manifest.xml $(ESMF_DIR)/manifest.xml
 
 
 # Copy the app rel directory to the staging directory to build our

--- a/package/smartos/epmd-manifest.xml
+++ b/package/smartos/epmd-manifest.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<service_bundle type="manifest" name="riak-epmd">
+  <service name="network/riak-epmd" type="service" version="1">
+    <create_default_instance enabled="false" />
+    <single_instance />
+    <dependency name="network" grouping="require_all" restart_on="error" type="service">
+      <service_fmri value="svc:/milestone/network:default" />
+    </dependency>
+    <dependency name="filesystem" grouping="require_all" restart_on="error" type="service">
+      <service_fmri value="svc:/system/filesystem/local" />
+    </dependency>
+    <method_context>
+      <method_credential user="riak" group="riak" />
+    </method_context>
+    <exec_method type="method" name="start" exec="/opt/local/share/smf/riak-epmd/riak-epmd start" timeout_seconds="60" />
+    <exec_method type="method" name="stop" exec=":kill" timeout_seconds="60" />
+    <property_group name="startd" type="framework">
+      <propval name="ignore_error" type="astring" value="core,signal" />
+    </property_group>
+    <property_group name="application" type="application"></property_group>
+    <stability value="Evolving" />
+    <template>
+      <common_name>
+        <loctext xml:lang="C">Erlang Port Mapper Daemon</loctext>
+      </common_name>
+    </template>
+  </service>
+</service_bundle>

--- a/package/smartos/manifest.xml
+++ b/package/smartos/manifest.xml
@@ -10,6 +10,9 @@
     <dependency name="filesystem" grouping="require_all" restart_on="error" type="service">
       <service_fmri value="svc:/system/filesystem/local" />
     </dependency>
+    <dependency name="riak-epmd" grouping="require_all" restart_on="error" type="service">
+      <service_fmri value="svc:/network/riak-epmd:default" />
+    </dependency>
     <method_context working_directory="/tmp" project="riak">
       <method_credential user="riak" group="riak" />
       <method_environment>
@@ -23,6 +26,7 @@
     </method_context>
     <exec_method type="method" name="start" exec="/opt/local/sbin/riak start" timeout_seconds="60" />
     <exec_method type="method" name="stop" exec="/opt/local/sbin/riak stop" timeout_seconds="60" />
+    <exec_method type="method" name="restart" exec="/opt/local/sbin/riak restart" timeout_seconds="60" />
     <property_group name="startd" type="framework">
       <propval name="duration" type="astring" value="contract" />
       <propval name="ignore_error" type="astring" value="core,signal" />

--- a/package/smartos/riak-epmd
+++ b/package/smartos/riak-epmd
@@ -1,0 +1,15 @@
+# Wrapper script for starting epmd
+
+. /lib/svc/share/smf_include.sh
+
+case "$1" in
+'start')
+        /opt/local/lib/riak/%ERTS_PATH%/bin/epmd -kill
+        /opt/local/lib/riak/%ERTS_PATH%/bin/epmd -daemon
+        ;;
+
+*)
+        exit 1
+        ;;
+esac
+exit 0


### PR DESCRIPTION
Riak is started and stopped on SmartOS using the [SMF system](http://wiki.joyent.com/display/smart/About+the+Service+Management+Facility). This system keeps track of every process started by a service.

This was causing difficulties with [epmd](http://www.erlang.org/doc/man/epmd.html) because that process would not shut down on `svcadm disable riak` causing Riak to go into a "maintenance" mode.

This pull request creates a separate SMF service for epmd called "riak-epmd".  This will do its best to start and stop epmd in a sane manner, allowing for Riak to be started and stopped also in sane way.

If an epmd process is active, but with no registered names, it is killed and restarted.

See: basho/riak_ee#75
