### PR TITLE
Declare that the 'folsom' app should be loaded, not started at boot time

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -143,13 +143,6 @@
             %% mode will be removed in a future release.
             {http_url_encoding, on},
 
-            %% riak_stat enables the use of the "riak-admin status" command to
-            %% retrieve information the Riak node for performance and debugging needs
-            {riak_kv_stat, true},
-
-            %% When using riak_kv_stat, use the legacy routines for tracking
-            {legacy_stats, true},
-
             %% Switch to vnode-based vclocks rather than client ids.  This
             %% significantly reduces the number of vclock entries.
             %% Only set true if *all* nodes in the cluster are upgraded to 1.0

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -28,7 +28,7 @@
          riak_control,
          erlydtl,
          riak_api,
-         folsom
+         {folsom, load}
         ]},
        {rel, "start_clean", "",
         [
@@ -77,4 +77,3 @@
            {mkdir, "lib/basho-patches"},
            {copy, "../ebin/etop_txt.beam", "lib/basho-patches"}
           ]}.
-


### PR DESCRIPTION
When a release was generated with r14 the folsom app was started at
boot time despite being an included app of riak_core. Setting the app_type()
to `load` in the reltool.config fixes this.

Tested on r14 and r15.

Also remove redundant app.config vars for stats.
