### PR TITLE
Added writable check for PIPE_DIR

### DIFF
--- a/rel/files/riak
+++ b/rel/files/riak
@@ -121,6 +121,12 @@ case "$1" in
         HEART_COMMAND="$RUNNER_SCRIPT_DIR/$SCRIPT start"
         export HEART_COMMAND
         mkdir -p $PIPE_DIR
+        if [ ! -w $PIPE_DIR ]; then
+            echo "Error writing to $PIPE_DIR"
+            echo "Delete this directory and try again."
+            exit 1
+        fi
+
         $ERTS_PATH/run_erl -daemon $PIPE_DIR $RUNNER_LOG_DIR \
             "exec $RUNNER_SCRIPT_DIR/$SCRIPT console" 2>&1
 


### PR DESCRIPTION
Re: Issue 192.

In certain situations PIPE_DIR exists and is owned by a different user.  This will silently crash riak start but riak console will succeed.
