### PR TITLE
Fix `platform_lib_dir` definition in packages to compare with devrel settings

### DIFF
--- a/package/deb/vars.config
+++ b/package/deb/vars.config
@@ -5,7 +5,8 @@
 {platform_bin_dir,  "/usr/sbin"}.
 {platform_data_dir, "/var/lib/riak"}.
 {platform_etc_dir,  "/etc/riak"}.
-{platform_lib_dir,  "/usr/lib/riak"}.
+{platform_base_dir, "/usr/lib/riak"}.
+{platform_lib_dir,  "{{platform_base_dir}}/lib"}.
 {platform_log_dir,  "/var/log/riak"}.
 
 %%
@@ -41,7 +42,7 @@
 %% bin/riak
 %%
 {runner_script_dir,  "/usr/sbin"}.
-{runner_base_dir,    "{{platform_lib_dir}}"}.
+{runner_base_dir,    "{{platform_base_dir}}"}.
 {runner_etc_dir,     "{{platform_etc_dir}}"}.
 {runner_log_dir,     "{{platform_log_dir}}"}.
 {pipe_dir,           "/tmp/riak/"}.

--- a/package/freebsd/vars.config
+++ b/package/freebsd/vars.config
@@ -5,7 +5,8 @@
 {platform_bin_dir,  "/usr/local/sbin"}.
 {platform_data_dir, "/var/db/riak"}.
 {platform_etc_dir,  "/usr/local/etc/riak"}.
-{platform_lib_dir,  "/usr/local/lib/riak"}.
+{platform_base_dir, "/usr/local/lib/riak"}.
+{platform_lib_dir,  "{{platform_base_dir}}/lib"}.
 {platform_log_dir,  "/var/log/riak"}.
 
 %%
@@ -41,7 +42,7 @@
 %% bin/riak
 %%
 {runner_script_dir,  "{{platform_bin_dir}}"}.
-{runner_base_dir,    "{{platform_lib_dir}}"}.
+{runner_base_dir,    "{{platform_base_dir}}"}.
 {runner_etc_dir,     "{{platform_etc_dir}}"}.
 {runner_log_dir,     "{{platform_log_dir}}"}.
 {pipe_dir,           "/tmp/riak/"}.

--- a/package/rpm/SPECS/riak.spec
+++ b/package/rpm/SPECS/riak.spec
@@ -31,7 +31,8 @@ Riak is a highly scalable, fault-tolerant distributed database
 %define platform_bin_dir %{_sbindir}
 %define platform_data_dir %{_localstatedir}/lib/%{name}
 %define platform_etc_dir %{_sysconfdir}/%{name}
-%define platform_lib_dir %{riak_lib}
+%define platform_base_dir %{riak_lib}
+%define platform_lib_dir %{platform_base_dir}/lib
 %define platform_log_dir %{_localstatedir}/log/%{name}
 
 %prep
@@ -43,6 +44,7 @@ cat > rel/vars.config <<EOF
 {platform_bin_dir,  "%{platform_bin_dir}"}.
 {platform_data_dir, "%{platform_data_dir}"}.
 {platform_etc_dir,  "%{platform_etc_dir}"}.
+{platform_base_dir, "%{platform_base_dir}"}.
 {platform_lib_dir,  "%{platform_lib_dir}"}.
 {platform_log_dir,  "%{platform_log_dir}"}.
 
@@ -79,7 +81,7 @@ cat > rel/vars.config <<EOF
 %% bin/riak
 %%
 {runner_script_dir,  "%{platform_bin_dir}"}.
-{runner_base_dir,    "%{platform_lib_dir}"}.
+{runner_base_dir,    "%{platform_base_dir}"}.
 {runner_etc_dir,     "%{platform_etc_dir}"}.
 {runner_log_dir,     "%{platform_log_dir}"}.
 {pipe_dir,           "/tmp/%{name}/"}.
@@ -96,6 +98,7 @@ make rel
 
 %install
 mkdir -p %{buildroot}%{platform_etc_dir}
+mkdir -p %{buildroot}%{platform_base_dir}
 mkdir -p %{buildroot}%{platform_lib_dir}
 mkdir -p %{buildroot}%{_mandir}/man1
 mkdir -p %{buildroot}%{platform_data_dir}/dets
@@ -109,11 +112,11 @@ mkdir -p %{buildroot}%{_localstatedir}/run/%{name}
 mkdir -p %{buildroot}%{platform_data_dir}/mr_queue
 
 #Copy all necessary lib files etc.
-cp -r $RPM_BUILD_DIR/%{name}-%{_revision}/rel/%{name}/lib %{buildroot}%{platform_lib_dir}
+cp -r $RPM_BUILD_DIR/%{name}-%{_revision}/rel/%{name}/lib %{buildroot}%{platform_base_dir}
 cp -r $RPM_BUILD_DIR/%{name}-%{_revision}/rel/%{name}/erts-* \
-                %{buildroot}%{platform_lib_dir}
+                %{buildroot}%{platform_base_dir}
 cp -r $RPM_BUILD_DIR/%{name}-%{_revision}/rel/%{name}/releases \
-                %{buildroot}%{platform_lib_dir}
+                %{buildroot}%{platform_base_dir}
 cp -r $RPM_BUILD_DIR/%{name}-%{_revision}/doc/man/man1/*.gz \
                 %{buildroot}%{_mandir}/man1
 install -p -D -m 0644 \
@@ -152,7 +155,7 @@ fi
 
 %post
 # Fixup perms for SELinux
-find %{platform_lib_dir} -name "*.so" -exec chcon -t textrel_shlib_t {} \;
+find %{platform_base_dir} -name "*.so" -exec chcon -t textrel_shlib_t {} \;
 
 %files
 %defattr(-,root,root)

--- a/package/smartos/vars.config
+++ b/package/smartos/vars.config
@@ -5,7 +5,8 @@
 {platform_bin_dir, "/opt/local/sbin"}.
 {platform_data_dir, "/var/db/riak"}.
 {platform_etc_dir, "/opt/local/etc/riak"}.
-{platform_lib_dir, "/opt/local/lib/riak"}.
+{platform_base_dir, "/opt/local/lib/riak"}.
+{platform_lib_dir, "{{platform_base_dir}}/lib"}.
 {platform_log_dir, "/var/log/riak"}.
 
 
@@ -42,7 +43,7 @@
 %% bin/riak
 %%
 {runner_script_dir,  "{{platform_bin_dir}}"}.
-{runner_base_dir,    "{{platform_lib_dir}}"}.
+{runner_base_dir,    "{{platform_base_dir}}"}.
 {runner_etc_dir,     "{{platform_etc_dir}}"}.
 {runner_log_dir,     "{{platform_log_dir}}"}.
 {pipe_dir,           "/tmp/riak/"}.


### PR DESCRIPTION
## Issue

In devrel and source builds, `platform_lib_dir` gets set to the `lib` directory that is created by reltool.  In all packages though, this directory is copied along with the `releases` and `erts-*` directories into the system lib directory.  So in all packages `platform_lib_dir` gets defined as a top level directory containing `lib`, `releases`, and `erts-*`.  The `riak` script attempts to set the load paths based on this `platform_lib_dir` setting so source builds act differently than package builds.  

See: basho/riak#126
## Change

This change fixes that inconsistency and defines a new variable `platform_base_dir` as the new system lib directory.  `platform_lib_dir` is then defined as `platform_base_dir/lib` to match up with devrel/source builds.
## Testing

This is easy to test by checking which etop is being called.
### Riak 1.2.0 test results (on Ubuntu 12.04)

``` shell
(riak@127.0.0.1)2>  code:which(etop_txt).
"/usr/lib/riak/lib/observer-1.1/ebin/etop_txt.beam"

(riak@127.0.0.1)3> code:get_path().
[".","/usr/lib/riak/lib/kernel-2.15.1/ebin",
 "/usr/lib/riak/lib/stdlib-1.18.1/ebin",
 "/usr/lib/riak/lib/sasl-2.2.1/ebin",
 "/usr/lib/riak/lib/crypto-2.1/ebin",
<snip> # no basho-patches listed
 "/usr/lib/riak/lib/riak_api-1.2.0/ebin",
 "/usr/lib/riak/lib/cluster_info-1.2.2/ebin",
 [...]|...]
```
### Package built from this branch results (also on Ubuntu 12.04)

``` shell
(riak@127.0.0.1)1> code:which(etop_txt).
"/usr/lib/riak/lib/basho-patches/etop_txt.beam"

(riak@127.0.0.1)2>  code:get_path().
["/usr/lib/riak/lib/basho-patches",".",
 "/usr/lib/riak/lib/kernel-2.15.1/ebin",
 "/usr/lib/riak/lib/stdlib-1.18.1/ebin",
 <snip>
 "/usr/lib/riak/lib/riak_search-1.2.0/ebin",
 "/usr/lib/riak/lib/riak_api-1.2.0/ebin",
 [...]|...]
(riak@127.0.0.1)3> 
```

In addition to make sure nothing else got borked in the process, I tested start/stop/ping, riak-admin test and uninstall package (to make sure directories are cleaned up).  The only platform tested was Ubuntu 12.04, so additional platforms should be tested.
