### PR TITLE
"Attempting sudo" should be on stderr

### DIFF
--- a/rel/files/riak
+++ b/rel/files/riak
@@ -36,7 +36,7 @@ if ([ "$RUNNER_USER" ] && [ "x$WHOAMI" != "x$RUNNER_USER" ]); then
         echo "sudo doesn't appear to be installed and your EUID isn't $RUNNER_USER" 1>&2
         exit 1
     fi
-    echo "Attempting to restart script through sudo -H -u $RUNNER_USER"
+    echo "Attempting to restart script through sudo -H -u $RUNNER_USER" >&2
     exec sudo -H -u $RUNNER_USER -i $RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT $@
 fi
 

--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -29,7 +29,7 @@ if ([ "$RUNNER_USER" ] && [ "x$WHOAMI" != "x$RUNNER_USER" ]); then
         echo "sudo doesn't appear to be installed and your EUID isn't $RUNNER_USER" 1>&2
         exit 1
     fi
-    echo "Attempting to restart script through sudo -H -u $RUNNER_USER"
+    echo "Attempting to restart script through sudo -H -u $RUNNER_USER" >&2
     exec sudo -H -u $RUNNER_USER -i $RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT $@
 fi
 

--- a/rel/files/search-cmd
+++ b/rel/files/search-cmd
@@ -24,7 +24,7 @@ if [ "$RUNNER_USER" -a "x$LOGNAME" != "x$RUNNER_USER" ]; then
         echo "sudo doesn't appear to be installed and your EUID isn't $RUNNER_USER" 1>&2
         exit 1
     fi
-    echo "Attempting to restart script through sudo -H -u $RUNNER_USER"
+    echo "Attempting to restart script through sudo -H -u $RUNNER_USER" >&2
     exec sudo -H -u $RUNNER_USER -i $RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT $@
 fi
 


### PR DESCRIPTION
My reasoning for this is that the "Attempting sudo..." output is more-or-less debug information that isn't relevant to the information you are asking for.  I like the output a lot, but I would also like to be able to filter it out for non-interactive uses of these tools.
### Example

before

```
dave @ [ dave-01 :: (SunOS) ] ~ $ version=$(riak version)
dave @ [ dave-01 :: (SunOS) ] ~ $ echo "$version"
Attempting to restart script through sudo -H -u riak
riak-ee (1.2.0 2012-08-06) SmartOS i386
```

In the above example, `$version` now contains two lines, which I would have to `tail -1` to filter out.

after

```
dave @ [ dave-01 :: (SunOS) ] ~ $ version=$(riak version)
Attempting to restart script through sudo -H -u riak
dave @ [ dave-01 :: (SunOS) ] ~ $ echo "$version"
riak-ee (1.2.0 2012-08-06) SmartOS i386
```

In this example, the debug output is printed when the command is invoked, and the `$version` variable only contains the version string.
