### PR TITLE
doc/raw-http-howto.txt:  Strike out-of-place comma

### DIFF
--- a/doc/raw-http-howto.txt
+++ b/doc/raw-http-howto.txt
@@ -93,7 +93,7 @@ To delete a document, simply issue a DELETE request:
 
 You'll find that further GETs of that URL return status code 404.
 
-For each of the key-level, document requests, you may also specify the
+For each of the key-level document requests, you may also specify the
 query parameters 'r', 'w', 'dw', and 'rw', to tune the R (read), W
 (write), DW (durable write), and RW (read-write, for delete) value for
 that request.  For instance:


### PR DESCRIPTION
Remove the comma in "key-level, document requests".  A comma separates
two modifiers of the same term, but "document" binds tighter, modifying
"requests" itself, whereas "key-level" modifies the compound term
"document requests" -- so a comma is no more appropriate here than it
would be in "striped candy cane".
