### PR TITLE
Add configuration option for 2i backpressure.

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -160,7 +160,14 @@
             %% > 1.0 is completed for a cluster, this should be set to
             %% true for better control of memory usage during key listing
             %% operations
-            {listkeys_backpressure, true}
+            {listkeys_backpressure, true},
+
+            %% This option toggles compatibility of secondary indexes
+            %% with 1.2.1 and earlier versions.  Once a rolling
+            %% upgrade to a version > 1.2.1 is completed for a
+            %% cluster, this should be set to true for better control
+            %% of memory usage during secondary index operations
+            {2i_backpressure, true}
            ]},
 
  %% Riak Search Config


### PR DESCRIPTION
Corresponds to [this](https://github.com/basho/riak_kv/pull/399) pr to add backpressure for 2I operations.
