### PR TITLE
Don't use lager console logging for release builds

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -208,13 +208,7 @@
             %% If you wish to disable rotation, you can either set the size to 0
             %% and the rotation time to "", or instead specify a 2-tuple that only
             %% consists of {Logfile, Level}.
-            {handlers, [
-                {lager_console_backend, info},
-                {lager_file_backend, [
-                    {"{{platform_log_dir}}/error.log", error, 10485760, "$D0", 5},
-                    {"{{platform_log_dir}}/console.log", info, 10485760, "$D0", 5}
-                ]}
-            ]},
+            {handlers, {{lager_handlers}} },
 
             %% Whether to write a crash log, and where.
             %% Commented/omitted/undefined means no crash logger.

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -31,6 +31,14 @@
 {reduce_js_vms, 6}.
 {hook_js_vms, 2}.
 
+%% lager
+{lager_handlers, "[ \
+                           {lager_file_backend, [ \
+                               {\"{{platform_log_dir}}/error.log\", error, 10485760, \"$D0\", 5}, \
+                               {\"{{platform_log_dir}}/console.log\", info, 10485760, \"$D0\", 5} \
+                           ]} \
+                       ]"}.
+
 %%
 %% etc/vm.args
 %%

--- a/rel/vars/dev1_vars.config
+++ b/rel/vars/dev1_vars.config
@@ -24,6 +24,15 @@
 {mapred_queue_dir,  "{{platform_data_dir}}/mr_queue"}.
 {merge_index_data_root,  "{{platform_data_dir}}/merge_index"}.
 
+%% lager
+{lager_handlers, "[ \
+                           {lager_console_backend, info}, \
+                           {lager_file_backend, [ \
+                               {\"{{platform_log_dir}}/error.log\", error, 10485760, \"$D0\", 5}, \
+                               {\"{{platform_log_dir}}/console.log\", info, 10485760, \"$D0\", 5} \
+                           ]} \
+                       ]"}.
+
 %% Javascript VMs
 {map_js_vms,   8}.
 {reduce_js_vms, 6}.

--- a/rel/vars/dev2_vars.config
+++ b/rel/vars/dev2_vars.config
@@ -24,6 +24,15 @@
 {mapred_queue_dir,  "{{platform_data_dir}}/mr_queue"}.
 {merge_index_data_root,  "{{platform_data_dir}}/merge_index"}.
 
+%% lager
+{lager_handlers, "[ \
+                           {lager_console_backend, info}, \
+                           {lager_file_backend, [ \
+                               {\"{{platform_log_dir}}/error.log\", error, 10485760, \"$D0\", 5}, \
+                               {\"{{platform_log_dir}}/console.log\", info, 10485760, \"$D0\", 5} \
+                           ]} \
+                       ]"}.
+
 %% Javascript VMs
 {map_js_vms,   8}.
 {reduce_js_vms, 6}.

--- a/rel/vars/dev3_vars.config
+++ b/rel/vars/dev3_vars.config
@@ -24,6 +24,15 @@
 {mapred_queue_dir,  "{{platform_data_dir}}/mr_queue"}.
 {merge_index_data_root,  "{{platform_data_dir}}/merge_index"}.
 
+%% lager
+{lager_handlers, "[ \
+                           {lager_console_backend, info}, \
+                           {lager_file_backend, [ \
+                               {\"{{platform_log_dir}}/error.log\", error, 10485760, \"$D0\", 5}, \
+                               {\"{{platform_log_dir}}/console.log\", info, 10485760, \"$D0\", 5} \
+                           ]} \
+                       ]"}.
+
 %% Javascript VMs
 {map_js_vms,   8}.
 {reduce_js_vms, 6}.

--- a/rel/vars/dev4_vars.config
+++ b/rel/vars/dev4_vars.config
@@ -24,6 +24,15 @@
 {mapred_queue_dir,  "{{platform_data_dir}}/mr_queue"}.
 {merge_index_data_root,  "{{platform_data_dir}}/merge_index"}.
 
+%% lager
+{lager_handlers, "[ \
+                           {lager_console_backend, info}, \
+                           {lager_file_backend, [ \
+                               {\"{{platform_log_dir}}/error.log\", error, 10485760, \"$D0\", 5}, \
+                               {\"{{platform_log_dir}}/console.log\", info, 10485760, \"$D0\", 5} \
+                           ]} \
+                       ]"}.
+
 %% Javascript VMs
 {map_js_vms,   8}.
 {reduce_js_vms, 6}.


### PR DESCRIPTION
Avoid redundant and potentially expsensive console logging in release builds. Move the lager handler configuration to be a template substitution so that console logging is still the default for devrel builds
