### PR TITLE
Adding support for using bloom filters in mapreduce jobs

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,5 +13,6 @@
        {riak_kv, ".*", {git, "git://github.com/basho/riak_kv", {branch, "master"}}},
        {riak_search, ".*", {git, "git://github.com/basho/riak_search",
                                 {branch, "master"}}},
-       {riak_control, ".*", {git, "git://github.com/basho/riak_control", {branch, "master"}}}
+       {riak_control, ".*", {git, "git://github.com/basho/riak_control", {branch, "master"}}},
+       {riakbloom, ".*", {git, "git://github.com/whitenode/riakbloom", {branch, "master"}}}
        ]}.

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -28,6 +28,7 @@
          lager,
          riak_control,
          erlydtl,
+         riakbloom,
          {folsom, load}
         ]},
        {rel, "start_clean", "",
@@ -54,6 +55,7 @@
        {app, lager, [{incl_cond, include}]},
        {app, riak_control, [{incl_cond, include}]},
        {app, riak_api, [{incl_cond, include}]},
+       {app, riakbloom, [{incl_cond, include}]},
        {app, folsom, [{incl_cond, include}]}
       ]}.
 


### PR DESCRIPTION
I have created a solution that allows bloom filters to be created, updated and used for filtering as part of mapreduce jobs. Part of the solution is a small OTP application that manages local caching of filters during map phase filtering as well as configuring the bucket used for filter storage on start-up. I have updated the rebar.config and reltool.config files to add the dependency on the riakbloom application and ensure this is started up together with Riak. Is this something you would consider integrating into Riak?

Best regards,

Christian
