### PR TITLE
Added `riak-admin cluster members`

### DIFF
--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -148,6 +148,22 @@ cluster_admin()
             ensure_node_running
             $NODETOOL rpc riak_core_console clear_staged
             ;;
+        members)
+            if [ $# -ne 1 ]; then
+                echo "Usage: $SCRIPT cluster $1"
+                exit 1
+            fi
+
+            # Make sure the local node IS running
+            RES=`$NODETOOL ping`
+            if [ "$RES" != "pong" ]; then
+                echo "Node is not running!"
+                exit 1
+            fi
+            shift
+
+            $NODETOOL rpc riak_core_console member_status $@
+            ;;
         *)
             echo "\
 Usage: $SCRIPT cluster <command>
@@ -175,6 +191,9 @@ Staging commands:
    plan                           Display the staged changes to the cluster
    commit                         Commit the staged changes
    clear                          Clear the staged changes
+
+Info commands:
+   members                        Display the current cluster members
 "
     esac
 }


### PR DESCRIPTION
This lets users see current cluster membership. It does exactly the
same as `riak-admin member-status` only it's in the cluster subcommand,
where I feel it should live.

I kept tripping up on the fact that the cluster membership commands weren't in the same place as the cluster altering commands, so I decided to make it so! Open Source ftw!

The old commands still work, and perhaps there's a better way of keeping backwards compatibility than duplicating code. I guess one can just call the other.
