### PR TITLE
Remove legacy listkeys config option

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -148,13 +148,6 @@
             %% Only set true if *all* nodes in the cluster are upgraded to 1.0
             {vnode_vclocks, true},
 
-            %% This option enables compatability of bucket and key listing
-            %% with 0.14 and earlier versions. Once a rolling upgrade to
-            %% a version > 0.14 is completed for a cluster, this should be
-            %% set to false for improved performance for bucket and key
-            %% listing operations.
-            {legacy_keylisting, false},
-
             %% This option toggles compatibility of keylisting with 1.0
             %% and earlier versions.  Once a rolling upgrade to a version
             %% > 1.0 is completed for a cluster, this should be set to


### PR DESCRIPTION
Legacy keylisting is being removed from riak_kv so the `legacy_keylisting` configuration option is now obsolete.
