### PR TITLE
Base architecture off of erlc binary class in OSX

### DIFF
--- a/package/Makefile
+++ b/package/Makefile
@@ -36,7 +36,8 @@ endif # solaris
 
 ifeq ($(OS),Darwin)          # OSX
 OSNAME		= OSX
-ARCH		= $(shell uname -m)
+ARCH            = $(shell file `which erlc` | grep -c x86_64 2> /dev/null | awk \
+                   '{if ($$1 == "0") {print "i386"} else {print "x86_64"}}')
 PKGERDIR	= osx
 BUILDDIR	= osxbuild
 endif


### PR DESCRIPTION
Like Solaris, OSX can have both i386 and x86_64 run natively
no matter how the kernel is compiled.  Using `uname` to determine
the architecture of the Riak package on OSX isn't correct on
OSX machines that report "i386" from `uname -m` but have Erlang
compiled for 64bit.

This method uses `file` to determine the architecture of the
`erlc` binary that will be in the path of the build since Erlang
is required to build Riak.  This way, the package architecture
will match the erlang architecture everytime.
