### PR TITLE
Set riak_sysmon's gc_ms_limit default value to zero

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -230,7 +230,9 @@
 
          %% Finding reasonable limits for a given workload is a matter
          %% of experimentation.
-         {gc_ms_limit, 100},
+         %% NOTE: Enabling the 'gc_ms_limit' monitor (by setting non-zero)
+         %%       can cause performance problems on multi-CPU systems.
+         {gc_ms_limit, 0},
          {heap_word_limit, 40111000},
 
          %% Configure the following items to 'false' to disable logging


### PR DESCRIPTION
Customer feedback during the Riak 1.2 release cycle has
demonstrated that the R15 virtual machine can have serious
mutex contention problems around the time-of-day clock when
Riak is under heavy load on "large" multi-core systems,
e.g. 24 core machines.  Setting the default value to zero
will disable the 'long_gc' system monitor messages.
