### PR TITLE
Properly exit on `/etc/init.d/riak status` command

### DIFF
--- a/package/rpm/SOURCES/riak_init
+++ b/package/rpm/SOURCES/riak_init
@@ -93,7 +93,7 @@ case "$1" in
         reload
         ;;
   status)
-        status
+        status && exit 0 || exit $?
         ;;
   ping)
         su - riak -c "$DAEMON ping" || exit $?


### PR DESCRIPTION
When running `/etc/init.d/riak status`, if the status fails
(Riak isn't running) not only should a message print out
that states that fact, but also the exit status should be non-zero.

This change addresses issue basho/riak#232 for RPM packages.

This PR is identical to https://github.com/basho/riak/pull/233 but got lost at the time.
