### PR TITLE
Add syslog support for lager to riak

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,6 +9,7 @@
 {erl_opts, [debug_info, fail_on_warning]}.
 
 {deps, [
+       {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog", {branch, "master"}}},
        {cluster_info, ".*", {git, "git://github.com/basho/cluster_info", {branch, "master"}}},
        {riak_kv, ".*", {git, "git://github.com/basho/riak_kv", {branch, "master"}}},
        {riak_search, ".*", {git, "git://github.com/basho/riak_search",

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -195,6 +195,11 @@
             %% If you wish to disable rotation, you can either set the size to 0
             %% and the rotation time to "", or instead specify a 2-tuple that only
             %% consists of {Logfile, Level}.
+            %%
+            %% If you wish to have riak log messages to syslog, you can use a handler
+            %% like this:
+            %%   {lager_syslog_backend, ["riak", daemon, info]},
+            %%
             {handlers, {{lager_handlers}} },
 
             %% Whether to write a crash log, and where.

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -6,6 +6,7 @@
         [
          kernel,
          stdlib,
+         lager,
          sasl,
          public_key,
          ssl,
@@ -24,7 +25,6 @@
          riak_search,
          riak_api,
          cluster_info,
-         lager,
          riak_control,
          erlydtl,
          {folsom, load}
@@ -49,6 +49,8 @@
        {app, riak_search, [{incl_cond, include}]},
        {app, eper, [{incl_cond, include}]},
        {app, sasl, [{incl_cond, include}]},
+       {app, syslog, [{incl_cond, include}]},
+       {app, lager_syslog, [{incl_cond, include}]},
        {app, lager, [{incl_cond, include}]},
        {app, riak_control, [{incl_cond, include}]},
        {app, riak_api, [{incl_cond, include}]},


### PR DESCRIPTION
Provide the necessary dependencies so that you can enable syslog as a lager backend for riak.

syslog and lager_syslog are included in the release, but not started by default because we don't want to unnecessarily load the port driver if we aren't going to use it.

To enable syslog support, add this under lager's section of the app.config

```
{handlers, [
                     {lager_syslog_backend, ["riak", daemon, info]},
                      ....     
                   ]},
```

That will make lager log any info messages (or above) to the daemon facility of syslog with the "riak" identity string.

Along with this, the code for https://github.com/basho/lager_syslog should probably be vetted, as we've never shipped it before.

lager_syslog is compatible with both lager 1.0.x, 1.2.x and 2.0.x (the upcoming lager release). As part of 1.3, we can pin the lager_syslog (and/or the lager) dependency to the 1.2.1 tag, instead of the current dependency on master.
