### PR TITLE
Remove unused bits of legacy-mapred configuration

### DIFF
--- a/package/deb/vars.config
+++ b/package/deb/vars.config
@@ -22,7 +22,6 @@
 {leveldb_data_root, "{{platform_data_dir}}/leveldb"}.
 {sasl_error_log,    "{{platform_log_dir}}/sasl-error.log"}.
 {sasl_log_dir,      "{{platform_log_dir}}/sasl"}.
-{mapred_queue_dir,  "{{platform_data_dir}}/mr_queue"}.
 
 %% riak_search
 {merge_index_data_root,  "{{platform_data_dir}}/merge_index"}.

--- a/package/freebsd/vars.config
+++ b/package/freebsd/vars.config
@@ -22,7 +22,6 @@
 {leveldb_data_root, "{{platform_data_dir}}/leveldb"}.
 {sasl_error_log,    "{{platform_log_dir}}/sasl-error.log"}.
 {sasl_log_dir,      "{{platform_log_dir}}/sasl"}.
-{mapred_queue_dir,  "{{platform_data_dir}}/mr_queue"}.
 
 %% riak_search
 {merge_index_data_root,  "{{platform_data_dir}}/merge_index"}.

--- a/package/rpm/SPECS/riak.spec
+++ b/package/rpm/SPECS/riak.spec
@@ -61,7 +61,6 @@ cat > rel/vars.config <<EOF
 {leveldb_data_root, "%{platform_data_dir}/leveldb"}.
 {sasl_error_log,    "%{platform_log_dir}/sasl-error.log"}.
 {sasl_log_dir,      "%{platform_log_dir}/sasl"}.
-{mapred_queue_dir,  "%{platform_data_dir}/mr_queue"}.
 
 %% riak_search
 {merge_index_data_root,  "%{platform_data_dir}/merge_index"}.

--- a/package/smartos/vars.config
+++ b/package/smartos/vars.config
@@ -23,7 +23,6 @@
 {leveldb_data_root, "{{platform_data_dir}}/leveldb"}.
 {sasl_error_log,    "{{platform_log_dir}}/sasl-error.log"}.
 {sasl_log_dir,      "{{platform_log_dir}}/sasl"}.
-{mapred_queue_dir,  "{{platform_data_dir}}/mr_queue"}.
 
 %% riak_search
 {merge_index_data_root,  "{{platform_data_dir}}/merge_index"}.

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -90,11 +90,6 @@
             %% undefined during a rolling upgrade from 1.0.
             {mapred_2i_pipe, true},
 
-            %% directory used to store a transient queue for pending
-            %% map tasks
-            %% Only valid when mapred_system == legacy
-            %% {mapred_queue_dir, "{{mapred_queue_dir}}" },
-
             %% Each of the following entries control how many Javascript
             %% virtual machines are available for executing map, reduce,
             %% pre- and post-commit hook functions.

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -97,12 +97,6 @@
             {reduce_js_vm_count, {{reduce_js_vms}} },
             {hook_js_vm_count, {{hook_js_vms}} },
 
-            %% Number of items the mapper will fetch in one request.
-            %% Larger values can impact read/write performance for
-            %% non-MapReduce requests.
-            %% Only valid when mapred_system == legacy
-            %% {mapper_batch_size, 5},
-
             %% js_max_vm_mem is the maximum amount of memory, in megabytes,
             %% allocated to the Javascript VMs. If unset, the default is
             %% 8MB.
@@ -112,12 +106,6 @@
             %% allocate to the Javascript VMs. If unset, the default is 16MB.
             %% NOTE: This is not the same as the C thread stack.
             {js_thread_stack, 16},
-
-            %% Number of objects held in the MapReduce cache. These will be
-            %% ejected when the cache runs out of room or the bucket/key
-            %% pair for that entry changes
-            %% Only valid when mapred_system == legacy
-            %% {map_cache_size, 10000},
 
             %% js_source_dir should point to a directory containing Javascript
             %% source files which will be loaded by Riak when it initializes

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -21,7 +21,6 @@
 {leveldb_data_root, "{{platform_data_dir}}/leveldb"}.
 {sasl_error_log,    "{{platform_log_dir}}/sasl-error.log"}.
 {sasl_log_dir,      "{{platform_log_dir}}/sasl"}.
-{mapred_queue_dir,  "{{platform_data_dir}}/mr_queue"}.
 
 %% riak_search
 {merge_index_data_root,  "{{platform_data_dir}}/merge_index"}.

--- a/rel/vars/dev_vars.config.src
+++ b/rel/vars/dev_vars.config.src
@@ -21,7 +21,6 @@
 {leveldb_data_root, "{{platform_data_dir}}/leveldb"}.
 {sasl_error_log,    "{{platform_log_dir}}/sasl-error.log"}.
 {sasl_log_dir,      "{{platform_log_dir}}/sasl"}.
-{mapred_queue_dir,  "{{platform_data_dir}}/mr_queue"}.
 {merge_index_data_root,  "{{platform_data_dir}}/merge_index"}.
 
 %% lager


### PR DESCRIPTION
The configuration settings `mapred_queue_dir`, `mapper_batch_size`, and `map_cache_size` are not used now that the legacy (Luke-based) MapReduce system has been removed. Remove them from config files to avoid confusion.
