### PR TITLE
Update top-level Riak for AAE

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -80,6 +80,46 @@
             %% details.
             %{raw_name, "riak"},
 
+            %% Enable active anti-entropy subsystem + optional debug messages:
+            %%   {anti_entropy, {on|off, []}},
+            %%   {anti_entropy, {on|off, [debug]}},
+            {anti_entropy, {on, []}},
+
+            %% Restrict how fast AAE can build hash trees. Building the tree
+            %% for a given partition requires a full scan over that partition's
+            %% data. Once built, trees stay built until they are expired.
+            %% Config is of the form:
+            %%   {num-builds, per-timespan-in-milliseconds}
+            %% Default is 1 build per hour.
+            {anti_entropy_build_limit, {1, 3600000}},
+
+            %% Determine how often hash trees are expired after being built.
+            %% Periodically expiring a hash tree ensures the on-disk hash tree
+            %% data stays consistent with the actual k/v backend data. It also
+            %% helps Riak identify silent disk failures and bit rot. However,
+            %% expiration is not needed for normal AAE operation and should be
+            %% infrequent for performance reasons. The time is specified in
+            %% milliseconds. The default is 1 week.
+            {anti_entropy_expire, 604800000},
+
+            %% Limit how many AAE exchanges/builds can happen concurrently.
+            {anti_entropy_concurrency, 2},
+
+            %% The tick determines how often the AAE manager looks for work
+            %% to do (building/expiring trees, triggering exchanges, etc).
+            %% The default is every 15 seconds. Lowering this value will
+            %% speedup the rate that all replicas are synced across the cluster.
+            %% Increasing the value is not recommended.
+            {anti_entropy_tick, 15000},
+
+            %% The directory where AAE hash trees are stored.
+            {anti_entropy_data_dir, "{{platform_data_dir}}/anti_entropy"},
+
+            %% The LevelDB options used by AAE to generate the LevelDB-backed
+            %% on-disk hashtrees.
+            {anti_entropy_leveldb_opts, [{write_buffer_size, 4194304},
+                                         {max_open_files, 20}]},
+
             %% mapred_name is URL used to submit map/reduce requests to Riak.
             {mapred_name, "mapred"},
 

--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -378,6 +378,17 @@ case "$1" in
         $NODETOOL rpc riak_core_console ring_status $@
         ;;
 
+    aae[_-]status)
+        if [ $# -ne 1 ]; then
+            echo "Usage: $SCRIPT $1"
+            exit 1
+        fi
+        shift
+
+        ensure_node_running
+        $NODETOOL rpc riak_kv_console aae_status $@
+        ;;
+
     cluster[_-]info)
         if [ $# -lt 2 ]; then
             echo "Usage: $SCRIPT $1 <output_file> ['local' | <node> ['local' | <node>] [...]]"
@@ -598,7 +609,7 @@ case "$1" in
         echo "                    reip | js-reload | erl-reload | wait-for-service | "
         echo "                    ringready | transfers | force-remove | down | "
         echo "                    cluster-info | member-status | ring-status | vnode-status |"
-        echo "                    diag | status | transfer-limit | "
+        echo "                    aae-status | diag | status | transfer-limit | "
         echo "                    top [-interval N] [-sort reductions|memory|msg_q] [-lines N] }"
         exit 1
         ;;


### PR DESCRIPTION
This pull-request adds the new `riak-admin aae_status` command that prints out the status of the AAE subsystem. This command is dependent upon status feature added in the sibling pull-request: basho/riak_kv#456

This pull-request also updates `app.config` with all the possible AAE configuration options along with documentation on each option.
