### PR TITLE
Change the erlang vm flags to force SMP use

### DIFF
--- a/rel/files/vm.args
+++ b/rel/files/vm.args
@@ -28,6 +28,9 @@
 ## Raise the ETS table limit
 -env ERL_MAX_ETS_TABLES 8192
 
+## Force the erlang VM to use SMP
+-smp enable
+
 ## Begin SSL distribution items, DO NOT DELETE OR EDIT THIS COMMENT
 
 ## To enable SSL encryption of the Erlang intra-cluster communication,


### PR DESCRIPTION
This addresses basho/riak#274 where Riak
failed to start and run on single CPU machines.
