### PR TITLE
Update rebar.config to point basho/yokozuna.git

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -17,6 +17,6 @@
                                  {tag, "1.3.0"}}},
        {riak_control, "1.3.0", {git, "git://github.com/basho/riak_control", {tag, "1.3.0"}}},
        {riaknostic, "1.1.0", {git, "git://github.com/basho/riaknostic", {tag, "v1.1.0"}}},
-       {yokozuna, ".*", {git, "git://github.com/rzezeski/yokozuna.git",
+       {yokozuna, ".*", {git, "git://github.com/basho/yokozuna.git",
                          {branch, "master"}}}
        ]}.


### PR DESCRIPTION
- Since the repository is moved under basho org,
  dependency point on rebar.config must be fixed
  to properly reflect the changes.
