### PR TITLE
Add missing rm -rf dev/$@/lib/riaknostic on dev target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ dev% : all riaknostic
 	mkdir -p dev
 	rel/gen_dev $@ rel/vars/dev_vars.config.src rel/vars/$@_vars.config
 	(cd rel && ../rebar generate target_dir=../dev/$@ overlay_vars=vars/$@_vars.config)
+	rm -rf dev/$@/lib/riaknostic
 	mkdir -p dev/$@/lib/riaknostic
 	cp -f deps/riaknostic/riaknostic dev/$@/lib/riaknostic/
 


### PR DESCRIPTION
Add a missing rm -rf on the copied riaknostic directory, which was preventing the dev targets such as stagedevrel from being rerun.  
