### PR TITLE
check if selinux is enabled before changing context

### DIFF
--- a/package/rpm/SPECS/riak.spec
+++ b/package/rpm/SPECS/riak.spec
@@ -162,7 +162,7 @@ fi
 
 %post
 # Fixup perms for SELinux
-find %{platform_base_dir} -name "*.so" -exec chcon -t textrel_shlib_t {} \;
+selinuxenabled && find %{platform_base_dir} -name "*.so" -exec chcon -t textrel_shlib_t {} \;
 
 %files
 %defattr(-,root,root)


### PR DESCRIPTION
prevents the following during installation:

```
chcon: can't apply partial context to unlabeled file «/usr/lib64/riak/lib/runtime_tools-1.8.8/priv/lib/dyntrace.so»
chcon: can't apply partial context to unlabeled file «/usr/lib64/riak/lib/runtime_tools-1.8.8/priv/lib/trace_file_drv.so»
chcon: can't apply partial context to unlabeled file «/usr/lib64/riak/lib/runtime_tools-1.8.8/priv/lib/trace_ip_drv.so»
chcon: can't apply partial context to unlabeled file «/usr/lib64/riak/lib/asn1-1.7/priv/lib/asn1_erl_nif.so»
chcon: can't apply partial context to unlabeled file «/usr/lib64/riak/lib/eleveldb-1.3.0/priv/eleveldb.so»
chcon: can't apply partial context to unlabeled file «/usr/lib64/riak/lib/bitcask-1.6.1/priv/bitcask.so»
chcon: can't apply partial context to unlabeled file «/usr/lib64/riak/lib/crypto-2.1/priv/lib/crypto.so»
chcon: can't apply partial context to unlabeled file «/usr/lib64/riak/lib/erlang_js-1.2.2/priv/erlang_js_drv.so»
chcon: can't apply partial context to unlabeled file «/usr/lib64/riak/lib/syslog-1.0.1/priv/syslog_drv.so»
```
