### PR TITLE
Move SSL distribution items into a regular configuration file.

### DIFF
--- a/rel/files/nodetool
+++ b/rel/files/nodetool
@@ -1,5 +1,5 @@
 #!/usr/bin/env escript
-%%! -args_file {{platform_data_dir}}/ssl_distribution.args_file
+%%! -args_file {{platform_etc_dir}}/ssl_distribution.args
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ft=erlang ts=4 sw=4 et
 %% -------------------------------------------------------------------

--- a/rel/files/riak
+++ b/rel/files/riak
@@ -24,7 +24,8 @@ RUNNER_LOG_DIR={{runner_log_dir}}
 PIPE_DIR={{pipe_dir}}
 RUNNER_USER={{runner_user}}
 PLATFORM_DATA_DIR={{platform_data_dir}}
-SSL_DIST_CONFIG=$PLATFORM_DATA_DIR/ssl_distribution.args_file
+SSL_DIST_CONFIG=$PLATFORM_ETC_DIR/ssl_distribution.args
+SSL_DIST_CONFIG_OLD=$PLATFORM_DATA_DIR/ssl_distribution.args_file
 RIAK_VERSION="git"
 
 WHOAMI=$(whoami)
@@ -110,10 +111,21 @@ get_pid() {
 }
 
 
-# Scrape out SSL distribution config info from vm.args into $SSL_DIST_CONFIG
-rm -f $SSL_DIST_CONFIG
-sed -n '/Begin SSL distribution items/,/End SSL distribution items/p' \
-    $RUNNER_ETC_DIR/vm.args > $SSL_DIST_CONFIG
+# If the old sed-generated SSL distribution file still exists and has
+# active settings in it, warn and exit. Otherwise, delete the old
+# file.
+if [ -f $SSL_DIST_CONFIG_OLD ]; then
+    grep -s "^\s*\-" $SSL_DIST_CONFIG_OLD > /dev/null;
+    if [ "$?" = "0" ]; then
+        echo "!!!!"
+        echo "!!!! This node uses SSL for intra-cluster communication. Please copy the settings from"
+        echo "!!!! $SSL_DIST_CONFIG_OLD into $SSL_DIST_CONFIG, remove $SSL_DIST_CONFIG_OLD and restart."
+        echo "!!!!"
+        exit 1
+    else
+        rm -f $SSL_DIST_CONFIG_OLD
+    fi
+fi
 
 # Check the first argument for instructions
 case "$1" in
@@ -290,7 +302,8 @@ case "$1" in
         CMD="$BINDIR/erlexec -boot $RUNNER_BASE_DIR/releases/$APP_VSN/$SCRIPT \
             -config $RUNNER_ETC_DIR/app.config \
             -pa $RUNNER_LIB_DIR/basho-patches \
-            -args_file $RUNNER_ETC_DIR/vm.args -- ${1+"$@"}"
+            -args_file $RUNNER_ETC_DIR/vm.args \
+            -args_file $SSL_DIST_CONFIG -- ${1+"$@"}"
         export EMU
         export ROOTDIR
         export BINDIR

--- a/rel/files/riak
+++ b/rel/files/riak
@@ -24,7 +24,7 @@ RUNNER_LOG_DIR={{runner_log_dir}}
 PIPE_DIR={{pipe_dir}}
 RUNNER_USER={{runner_user}}
 PLATFORM_DATA_DIR={{platform_data_dir}}
-SSL_DIST_CONFIG=$PLATFORM_ETC_DIR/ssl_distribution.args
+SSL_DIST_CONFIG=$RUNNER_ETC_DIR/ssl_distribution.args
 SSL_DIST_CONFIG_OLD=$PLATFORM_DATA_DIR/ssl_distribution.args_file
 RIAK_VERSION="git"
 

--- a/rel/files/ssl_distribution.args
+++ b/rel/files/ssl_distribution.args
@@ -2,6 +2,6 @@
 ## un-comment the three lines below and make certain that the paths
 ## point to correct PEM data files.
 
-## -proto_dist inet_ssl
+## -proto_dist inet_tls
 ## -ssl_dist_opt client_certfile "{{platform_etc_dir}}/erlclient.pem"
 ## -ssl_dist_opt server_certfile "{{platform_etc_dir}}/erlserver.pem"

--- a/rel/files/ssl_distribution.args
+++ b/rel/files/ssl_distribution.args
@@ -1,0 +1,7 @@
+## To enable SSL encryption of the Erlang intra-cluster communication,
+## un-comment the three lines below and make certain that the paths
+## point to correct PEM data files.
+
+## -proto_dist inet_ssl
+## -ssl_dist_opt client_certfile "{{platform_etc_dir}}/erlclient.pem"
+## -ssl_dist_opt server_certfile "{{platform_etc_dir}}/erlserver.pem"

--- a/rel/files/vm.args
+++ b/rel/files/vm.args
@@ -31,15 +31,4 @@
 ## Force the erlang VM to use SMP
 -smp enable
 
-## Begin SSL distribution items, DO NOT DELETE OR EDIT THIS COMMENT
-
-## To enable SSL encryption of the Erlang intra-cluster communication,
-## un-comment the three lines below and make certain that the paths
-## point to correct PEM data files.  See docs TODO for details.
-
-## -proto_dist inet_ssl
-## -ssl_dist_opt client_certfile "{{platform_etc_dir}}/erlclient.pem"
-## -ssl_dist_opt server_certfile "{{platform_etc_dir}}/erlserver.pem"
-
-## End SSL distribution items, DO NOT DELETE OR EDIT THIS COMMENT
-
+## NOTE: SSL Distribution settings have moved to {{platform_etc_dir}}/ssl_distribution.args

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -72,6 +72,7 @@
            {template, "files/riak-admin", "bin/riak-admin"},
            {template, "files/search-cmd", "bin/search-cmd"},
            {template, "files/vm.args", "etc/vm.args"},
+           {template, "files/ssl_distribution.args", "etc/ssl_distribution.args"},
            {template, "files/cert.pem", "etc/cert.pem"},
            {template, "files/key.pem", "etc/key.pem"},
            {mkdir, "lib/basho-patches"},


### PR DESCRIPTION
Before this change, `sed` was used to find some "magic comments" in `etc/vm.args` and slurp them into a file that is writeable by the `riak` script, so that `nodetool` could use that file as arguments to its init process, and thus be able to connect to a Riak node using the SSL distribution.

This is wholly unnecessary, given that the emulator can accept multiple `-args_file` command-line arguments. Instead, we now separate the totally-optional-and-mostly-unused SSL settings into `etc/ssl_distribution.args`, which can be used independently by `nodetool` and in conjunction with `etc/vm.args` by the normal node boot process.

In order to support upgrades, the `riak` script checks for the presence of the old `sed`-slurped file. If it is present and contains active configuration items, a warning is presented and the script exits non-zero. If the file exists and only contains comments, it is deleted. Downgrades are not explicitly supported.
