### PR TITLE
Add health check deprecation note to config

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -65,7 +65,12 @@
               %% If disabled, health checks registered by an application will
               %% be ignored. NOTE: this option cannot be changed at runtime.
               %% To re-enable, the setting must be changed and the node restarted.
-              {enable_health_checks, true},
+              %% NOTE: As of Riak 1.3.2, health checks are deprecated as they
+              %% may interfere with the new overload protection mechanisms.
+              %% If there is a good reason to re-enable them, you must uncomment
+              %% this line and also add an entry in the riak_kv section:
+              %%          {riak_kv, [ ..., {enable_health_checks, true}, ...]}
+              %% {enable_health_checks, true},
 
               %% Platform-specific installation paths (substituted by rebar)
               {platform_bin_dir, "{{platform_bin_dir}}"},


### PR DESCRIPTION
/cc @jaredmorrow @jtuple 
Let me know if you have any comments on the wording of this note and stuff. Should be moved to riak_ee and 1.4 before release.

Health checks will be disabled anyway, but this should clear some confusion on users of fresh deployments
