### PR TITLE
update vm.args for moving to OTP team scheduler patch

### DIFF
--- a/rel/files/vm.args
+++ b/rel/files/vm.args
@@ -45,8 +45,8 @@
 ## Erlang VM scheduler tuning.
 ## Prerequisite: a patched VM from Basho, or a VM compiled separately
 ## with this patch applied:
-##     https://gist.github.com/slfritchie/5624609
-##+scl false +zdss 50:50
+##     https://gist.github.com/evanmcc/a599f4c6374338ed672e
+##+sfwi 500
 
 ## Begin SSL distribution items, DO NOT DELETE OR EDIT THIS COMMENT
 


### PR DESCRIPTION
should also go into the 1.3 branch.
