### PR TITLE
riak-admin downgrade-objects

### DIFF
--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -24,10 +24,11 @@ SCRIPT=`basename $0`
 usage() {
     echo "Usage: $SCRIPT { cluster | join | leave | backup | restore | test | "
     echo "                    reip | js-reload | erl-reload | wait-for-service | "
-    echo "                    ringready | transfers | force-remove | down | "
+    echo "                    ringready | transfers | force-remove | down |"
     echo "                    cluster-info | member-status | ring-status | vnode-status |"
     echo "                    aae-status | diag | status | transfer-limit | reformat-indexes |"
-    echo "                    top [-interval N] [-sort reductions|memory|msg_q] [-lines N] }"
+    echo "                    top [-interval N] [-sort reductions|memory|msg_q] [-lines N] |"
+    echo "                    downgrade-objects }"
 }
 
 cluster_admin()

--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -509,6 +509,15 @@ case "$1" in
         shift
         $NODETOOL rpc riak_kv_console reformat_indexes "$@"
         ;;
+    downgrade[_-]objects)
+        if [ $# -lt 2 ]; then
+            echo "Usage: $SCRIPT $1 <kill-handoffs> [<concurrency>]"
+            exit
+        fi
+        node_up_check
+        shift
+        $NODETOOL rpc riak_kv_console reformat_objects "$@"
+        ;;
     *)
         usage
         exit 1


### PR DESCRIPTION
wire up riak_kv_console:reformat_objects/1 to riak-admin. command
is called "downgrade-objects" to avoid confusion since that is the
only thing currently supported

relies on: https://github.com/basho/riak_kv/pull/585
