### PR TITLE
Include leveldb source code in riak source distribution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,8 +159,22 @@ MAJOR_VERSION	?= $(shell echo $(REVISION) | sed -e 's/\([0-9.]*\)-.*/\1/')
 ## Generates a tarball that includes all the deps sources so no checkouts are necessary
 ##
 
-# Use git archive to copy a repository at a current revision to a new directory
+# Use git archive make a clean copy of a repository at a current
+# revision and copy to a new directory
 archive_git = git archive --format=tar --prefix=$(1)/ HEAD | (cd $(2) && tar xf -)
+
+# Alternative to git archive to remove .git directory, but not any
+# other files outside of the source tree (used for eleveldb which
+# brings in leveldb)
+clean_git = cp -R ../../$(1) $(2)/deps/ && find $(2)/$(1) -name .git -type d | xargs rm -rf
+
+# Determines which function to call.  eleveldb is treated as a special case
+archive = if [ "$(1)" = "deps/eleveldb" ]; then \
+              $(call clean_git,$(1),$(2)); \
+          else \
+              $(call archive_git,$(1),$(2)); \
+          fi
+
 
 # Checkout tag, fetch deps (so we don't have to do it multiple times) and collect
 # the version of all the dependencies into the MANIFEST_FILE
@@ -202,10 +216,11 @@ build_clean_dir = cd distdir/$(CLONEDIR) && \
                   mkdir ../$(PKG_ID)/deps && \
                   for dep in deps/*; do \
                       cd $${dep} && \
-                      $(call archive_git,$${dep},../../../$(PKG_ID)) && \
-                      mkdir -p ../../../$(PKG_ID)/$${dep}/priv && \
-                      printf "`git describe --long --tags 2>/dev/null || git rev-parse HEAD`" > ../../../$(PKG_ID)/$${dep}/priv/vsn.git && \
-                      cd ../..; done
+                           $(call archive,$${dep},../../../$(PKG_ID)) && \
+                           mkdir -p ../../../$(PKG_ID)/$${dep}/priv && \
+                           printf "`git describe --long --tags 2>/dev/null || git rev-parse HEAD`" > ../../../$(PKG_ID)/$${dep}/priv/vsn.git && \
+                           cd ../..; \
+                  done
 
 
 distdir/$(CLONEDIR)/$(MANIFEST_FILE):


### PR DESCRIPTION
When building riak's source tarball, `git archive` is used
to ensure clean repositories are used rather than working
directories that might have uncommited changes.  This works
fine except for one special case where eleveldb downloads
leveldb into its source tree.  In this case 'git archive'
then removes the leveldb source because it is not truly
a committed file in eleveldb's repository.

The side effect of this issue are users who try to build
riak from source while either offline or without access
to github while building.  Any build will fail because
eleveldb does not have leveldb's source tree that is needed.

This commit fixes that by using a work around to `git archive`
in the one special case of eleveldb.  The `.git` directories
are still cleaned, but the leveldb source tree is left intact.

The one downside to this change is eleveldb is not treated
differently than every other repository and local changes
to eleveldb's source tree can possibly leak into the source
tarball.  This however is very unlikely due to `make dist`
using a completely separate `make deps` chain than the standard
developer `make deps`.  Basically someone would have to really
try hard to mess it up.

This addresses basho/riak#345
#### How to Test

Here is the already built source tarball of this branch: https://dl.dropboxusercontent.com/u/183971/riak-1.4.0rc1-ad85a134.tar.gz

Here is the link to the 1.4.0rc1 source tarball: http://s3.amazonaws.com/downloads.basho.com/riak/1.4/1.4.0rc1/riak-1.4.0rc1.tar.gz
- download each source tarball
- unpack each tarball
- disconnect your network or add "127.0.0.1 github.com" to your `/etc/hosts` file
- in each untarred directory try to `make rel`

The 1.4.0rc1 tar will fail, the new one will pass.
#### My testing

I've built this on all platforms to prove I didn't add any platform incompatibilities with my `find` call.  The passing builds can be seen here: 

![screen shot 2013-06-27 at 11 26 28 pm](https://f.cloud.github.com/assets/718326/723534/986592e0-e01a-11e2-961d-eaf61d332368.png)

I also compared the `tree` output of the two different source builds by running `make dist` on `riak-1.4.0rc1` and `jem-dist-include-leveldb` to make sure the `.git` directories were still cleaned and no other files were lost in the change.

I added the one 'gotcha' to the commit text that mentions eleveldb being handled differently than all other repos.  It would be next to impossible to accidentally build working-copy code even with this change as toplevel is still clean cloned to `distdir/riak-clone` directory before these changed steps even happen.
