### PR TITLE
Move http settings to riak_api.

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -3,6 +3,15 @@
 [
  %% Riak Client APIs config
  {riak_api, [
+
+            %% http is a list of IP addresses and TCP ports that the Riak
+            %% HTTP interface will bind.
+            {http, [ {"{{web_ip}}", {{web_port}} } ]},
+
+            %% https is a list of IP addresses and TCP ports that the Riak
+            %% HTTPS interface will bind.
+            %% {https, [{ "{{web_ip}}", {{web_port}} }]},
+
             %% pb_backlog is the maximum length to which the queue of pending
             %% connections may grow. If set, it must be an integer >= 0.
             %% By default the value is 5. If you anticipate a huge number of
@@ -23,14 +32,6 @@
               %% Default ring creation size.  Make sure it is a power of 2,
               %% e.g. 16, 32, 64, 128, 256, 512 etc
               %{ring_creation_size, 64},
-
-              %% http is a list of IP addresses and TCP ports that the Riak
-              %% HTTP interface will bind.
-              {http, [ {"{{web_ip}}", {{web_port}} } ]},
-
-              %% https is a list of IP addresses and TCP ports that the Riak
-              %% HTTPS interface will bind.
-              %{https, [{ "{{web_ip}}", {{web_port}} }]},
 
               %% Default cert and key locations for https can be overridden
               %% with the ssl config variable, for example:


### PR DESCRIPTION
This moves configuration for the HTTP client interface to `riak_api`. These PRs are required for this to work:
- basho/riak_core#355
- basho/riak_api#34
- basho/riak_test#375
