### PR TITLE
corrected a schema transcription error

### DIFF
--- a/rel/files/riak.schema
+++ b/rel/files/riak.schema
@@ -985,7 +985,7 @@ end}.
 %% before leveldb responded with “write good”. The reality in modern servers 
 %% is that many layers of data caching exist between the database program and 
 %% the physical disks. This flag influences only one of the layers.
-{mapping, "leveldb.cache_size", "eleveldb.cache_size", [
+{mapping, "leveldb.sync", "eleveldb.sync", [
   {default, false},
   {datatype, enum},
   {enum, [true, false]},


### PR DESCRIPTION
when transcribing the riak schema, I fat fingered a copy/paste, putting two entries in for leveldb.cache_size.

One was supposed to be leveldb.sync.
