### PR TITLE
Let YZ create its data dir

### DIFF
--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -105,7 +105,5 @@
            {mkdir, "lib/basho-patches"},
            {copy, "../ebin/etop_txt.beam", "lib/basho-patches"},
 
-           {mkdir, "{{yz_dir}}"},
-           {template, "../deps/yokozuna/rel_etc/solr-log4j.properties", "etc/solr-log4j.properties"},
-           {template, "../deps/yokozuna/rel_data/solr.xml", "{{yz_dir}}/solr.xml"}
+           {template, "../deps/yokozuna/rel_etc/solr-log4j.properties", "etc/solr-log4j.properties"}
           ]}.


### PR DESCRIPTION
As of basho/yokozuna#173, yokozuna handles creation of its data directory (and solr config) at startup. No need to do it here at build/installation time.
