### PR TITLE
Add missing rel storage value

### DIFF
--- a/rel/vars.config
+++ b/rel/vars.config
@@ -16,6 +16,7 @@
 {handoff_port,      8099}.
 {pb_ip,             "127.0.0.1"}.
 {pb_port,           8087}.
+{storage_backend,   "bitcask"}.
 {ring_state_dir,    "{{platform_data_dir}}/ring"}.
 {bitcask_data_root, "{{platform_data_dir}}/bitcask"}.
 {leveldb_data_root, "{{platform_data_dir}}/leveldb"}.


### PR DESCRIPTION
With the addition of the smoke test, storage backend was made into a
variable and perf_dev and devrel targets were updated, but not the rel
target. This adds the missing default storage of "bitcask".
