### PR TITLE
fixed handing riak_control.user

### DIFF
--- a/rel/files/riak.schema
+++ b/rel/files/riak.schema
@@ -687,15 +687,12 @@ end}.
 {translation,
 "riak_control.userlist",
 fun(Conf) ->
-  UserList1 = lists:filter(
+  UserList = lists:filter(
     fun({K, _V}) -> 
-      cuttlefish_util:fuzzy_variable_match(K, "riak_control.user.$username.password")
+      cuttlefish_util:fuzzy_variable_match(K, string:tokens("riak_control.user.$username.password", "."))
     end,
     Conf),
-  UserList = [ begin
-    [_, _, Username, _] = string:tokens(Key, "."),
-    {Username, Password}
-  end || {Key, Password} <- UserList1]
+  [ {Username, Password} || {[_, _, Username, _], Password} <- UserList ]
 
 end}.
 


### PR DESCRIPTION
Generated app.config doesn't include riak_control username and pass as userlist even if it's configured.

before fix

```
% grep riak_control app.2013.10.02.02.33.17.config
 {riak_control,[{enabled,true},{auth,userlist},{userlist,[]},{admin,true}]},
```

after fix

```
% grep -A 4 riak_control app.2013.10.02.10.09.40.config
 {riak_control,
     [{enabled,false},
      {auth,userlist},
      {userlist,[{"user","pass"}]},
      {admin,true}]},
```
