### PR TITLE
make reltool create generated configs dir

### DIFF
--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -72,6 +72,7 @@
 
 {overlay, [
            {mkdir, "data/ring"},
+           {mkdir, "data/generated.configs"},
            {mkdir, "log"},
 
            %% Copy base files for starting and interacting w/ node


### PR DESCRIPTION
I needed this to make "make rel" work on head of the develop branch.
