### PR TITLE
Add https port to gen_dev and rebar overlay

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -30,7 +30,7 @@
 
               %% https is a list of IP addresses and TCP ports that the Riak
               %% HTTPS interface will bind.
-              %{https, [{ "{{web_ip}}", {{web_port}} }]},
+              %{https, [{ "{{web_ip}}", {{https_port}} }]},
 
               %% Default cert and key locations for https can be overridden
               %% with the ssl config variable, for example:

--- a/rel/gen_dev
+++ b/rel/gen_dev
@@ -18,10 +18,12 @@ NUMBER=${NAME##dev}
 BASE=$((10000 + 10 * $NUMBER))
 PBPORT=$(($BASE + 7))
 WEBPORT=$(($BASE + 8))
+HTTPSPORT=$(($BASE + 6))
 HANDOFFPORT=$(($BASE + 9))
 
-echo "Generating $NAME - node='$NODE' pbc=$PBPORT http=$WEBPORT handoff=$HANDOFFPORT"
+echo "Generating $NAME - node='$NODE' pbc=$PBPORT http=$WEBPORT handoff=$HANDOFFPORT https=$HTTPSPORT"
 sed -e "s/@NODE@/$NODE/" \
     -e "s/@PBPORT@/$PBPORT/" \
     -e "s/@WEBPORT@/$WEBPORT/" \
+    -e "s/@HTTPSPORT@/$HTTPSPORT/" \
     -e "s/@HANDOFFPORT@/$HANDOFFPORT/" < $TEMPLATE > $VARFILE

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -13,6 +13,7 @@
 %%
 {web_ip,            "127.0.0.1"}.
 {web_port,          8098}.
+{https_port,        8096}.
 {handoff_port,      8099}.
 {pb_ip,             "127.0.0.1"}.
 {pb_port,           8087}.

--- a/rel/vars/dev_vars.config.src
+++ b/rel/vars/dev_vars.config.src
@@ -13,6 +13,7 @@
 %%
 {web_ip,            "127.0.0.1"}.
 {web_port,          @WEBPORT@}.
+{https_port,        @HTTPSPORT@}.
 {handoff_port,      @HANDOFFPORT@}.
 {pb_ip,             "127.0.0.1"}.
 {pb_port,           @PBPORT@}.


### PR DESCRIPTION
Changing the https port manually for all my devs each rebuild was
getting annoying, so I added a new variable `https_port` to
dev_vars.config and changed gen_dev accordingly. For consistency, I
also added the variable to vars.config.
