### PR TITLE
Resolve reip so that it uses the proper cuttlefish configuration files.

### DIFF
--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -519,11 +519,18 @@ case "$1" in
         # Make sure the local node is running
         node_down_check
 
+        # Sanity check the app.config file
+        check_config
+        ES=$?
+        if [ "$ES" -ne 0 ]; then
+            exit $ES
+        fi
+
         OLDNODE=$1
         NEWNODE=$2
         $ERTS_PATH/erl -noshell \
             -pa $RUNNER_LIB_DIR/basho-patches \
-            -config $RUNNER_ETC_DIR/app.config \
+            $CONFIG_ARGS \
             -eval "riak_kv_console:$ACTION(['$OLDNODE', '$NEWNODE'])" \
             -s init stop
         ;;


### PR DESCRIPTION
As best as I can tell, we don't need to worry about the configuration
being edited, because it appears that reip only modifies the ring files,
and not the vm.args or app.config.
