### PR TITLE
Add riak_ensemble to reltool.config

### DIFF
--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -29,7 +29,8 @@
          riak_control,
          erlydtl,
          riak_auth_mods,
-         {folsom, load}
+         {folsom, load},
+         {riak_ensemble, load}
         ]},
        {rel, "start_clean", "",
         [
@@ -62,7 +63,8 @@
        {app, lager, [{incl_cond, include}]},
        {app, riak_control, [{incl_cond, include}]},
        {app, riak_api, [{incl_cond, include}]},
-       {app, folsom, [{incl_cond, include}]}
+       {app, folsom, [{incl_cond, include}]},
+       {app, riak_ensemble, [{incl_cond, include}]}
       ]}.
 
 


### PR DESCRIPTION
Add [riak_ensemble](http://github.com/basho/riak_ensemble) as an included/loaded (but not started) app. `riak_ensemble` is actually started by `riak_core` via basho/riak_core#441
