### PR TITLE
preparation for configurable name of cuttlefish conf files

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -25,4 +25,4 @@
         {rebar_lock_deps_plugin, ".*", {git, "git://github.com/seth/rebar_lock_deps_plugin.git", {branch, "master"}}}
        ]}.
 
-{plugins, [cuttlefish_rebar_plugin, rebar_lock_deps_plugin]}.
+{plugins, [rebar_lock_deps_plugin]}.

--- a/rel/rebar.config
+++ b/rel/rebar.config
@@ -1,3 +1,4 @@
 {lib_dirs, ["../deps"]}.
 {plugin_dir, "../deps/cuttlefish/src"}.
 {plugins, [cuttlefish_rebar_plugin]}.
+{cuttlefish_filename, "riak.conf"}.


### PR DESCRIPTION
In order to make cuttlefish accept a conf filename as a configuration parameter, I needed to add a default which is not `riak.conf`. it's `cuttlefish.conf`. Anyway, if this lands in riak first, it won't be an issue.

Also, I figured out that I didn't need the cuttlefish plugin in the main rebar.config, only the one in rel.
