### PR TITLE
remove ebloom app from rel/reltool.config

### DIFF
--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -48,7 +48,6 @@
        {app, cuttlefish, [{incl_cond, include}]},
        {app, cluster_info, [{incl_cond, include}]},
        {app, erlang_js, [{incl_cond, include}]},
-       {app, ebloom, []},
        {app, riaknostic, [{incl_cond, include}]},
        {app, bitcask, [{incl_cond, include}]},
        {app, riak_core, [{incl_cond, include}]},


### PR DESCRIPTION
The ebloom app dependency was removed from the riak_kv repo in commit
8bd8cde, and is not used in riak, so remove it from reltool.config.
