### PR TITLE
Turn on leveldb developer mode when building devrels

### DIFF
--- a/rel/files/riak.schema
+++ b/rel/files/riak.schema
@@ -185,3 +185,15 @@ end}.
 {mapping, "distributed_cookie", "vm_args.-setcookie", [
   {default, "riak"}
 ]}.
+
+{{#devrel}}
+%% @doc limited_developer_mem is a Riak specific option that is used
+%% when a developer is testing a high number of vnodes and/or several
+%% VMs on a machine with limited physical memory.  Do NOT use this
+%% option if making performance measurements.  This option overwrites
+%% values given to write_buffer_size_min and write_buffer_size_max.
+{mapping, "leveldb.limited_developer_mem", "eleveldb.limited_developer_mem", [
+  {default, true},
+  {datatype, {enum, [true, false]}}
+]}.
+{{/devrel}}

--- a/rel/vars/dev_vars.config.src
+++ b/rel/vars/dev_vars.config.src
@@ -1,6 +1,8 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ft=erlang ts=4 sw=4 et
 
+{devrel, true}.
+
 %% Platform-specific installation paths
 {platform_bin_dir,  "./bin"}.
 {platform_data_dir, "./data"}.


### PR DESCRIPTION
I don't know if I did this right, but it seems to work? Without this all the replication tests on giddyup fail because when the 5th or 6th node starts the VM is out of RAM.

cc @jaredmorrow  @joedevivo @matthewvon 
