### PR TITLE
Confbal schema robustification effort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ rel/vars/dev*_vars.config
 dev/
 perfdev/
 ebin/
+apps/riak/.eunit

--- a/apps/riak/test/riak_schema_test.erl
+++ b/apps/riak/test/riak_schema_test.erl
@@ -1,0 +1,105 @@
+-module(riak_schema_test).
+-include_lib("eunit/include/eunit.hrl").
+-compile(export_all).
+
+basic_schema_test() ->
+    Config = cuttlefish_unit:generate_templated_config(
+               ["../../../rel/files/riak.schema"], [], context()),
+
+    cuttlefish_unit:assert_config(Config, "lager.handlers",
+                                  [
+                                   {lager_file_backend, [{file, "./log/console.log"},
+                                                         {level, info},
+                                                         {size, 10485760},
+                                                         {date, "$D0"},
+                                                         {count, 5}]},
+                                   {lager_file_backend, [{file, "./log/error.log"},
+                                                         {level, error},
+                                                         {size, 10485760},
+                                                         {date, "$D0"},
+                                                         {count, 5}]}
+                                  ]),
+    cuttlefish_unit:assert_config(Config, "sasl.sasl_error_logger", false),
+    cuttlefish_unit:assert_config(Config, "lager.crash_log", "./log/crash.log"),
+    cuttlefish_unit:assert_config(Config, "lager.crash_log_msg_size", 64 * 1024),
+    cuttlefish_unit:assert_config(Config, "lager.crash_log_size", 10 * 1024 * 1024),
+    cuttlefish_unit:assert_config(Config, "lager.crash_log_date", "$D0"),
+    cuttlefish_unit:assert_config(Config, "lager.crash_log_count", 5),
+    cuttlefish_unit:assert_config(Config, "lager.error_logger_redirect", true),
+    cuttlefish_unit:assert_config(Config, "lager.error_logger_hwm", 100),
+    cuttlefish_unit:assert_config(Config, "vm_args.-setcookie", "riak"),
+    ok.
+
+override_schema_test() ->
+    Conf = [{["log", "console"], both},
+            {["log", "console", "level"], debug},
+            {["log", "console", "file"], "/var/log/foo.log"},
+            {["log", "error", "file"], "/var/log/errors.log"},
+            {["log", "syslog"], on},
+            {["sasl"], on},
+            {["log", "crash", "file"], "/var/log/crashy.log"},
+            {["log", "crash", "maximum_message_size"], "1KB"},
+            {["log", "crash", "size"], "2KB"},
+            {["log", "crash", "rotation"], "$W0"},
+            {["log", "crash", "rotation", "keep"], current},
+            {["log", "error", "redirect"], off},
+            {["log", "error", "messages_per_second"], 50},
+            {["distributed_cookie"], "tyktorp"}],
+
+    Config = cuttlefish_unit:generate_templated_config(
+               ["../../../rel/files/riak.schema"], Conf, context()),
+
+    cuttlefish_unit:assert_config(Config, "lager.handlers",
+                                  [{lager_syslog_backend, ["riak", daemon, info]},
+                                   {lager_console_backend, debug},
+                                   {lager_file_backend, [{file, "/var/log/foo.log"},
+                                                         {level, debug},
+                                                         {size, 10485760},
+                                                         {date, "$D0"},
+                                                         {count, 5}]},
+                                   {lager_file_backend, [{file, "/var/log/errors.log"},
+                                                         {level, error},
+                                                         {size, 10485760},
+                                                         {date, "$D0"},
+                                                         {count, 5}]}
+                                  ]),
+    cuttlefish_unit:assert_config(Config, "sasl.sasl_error_logger", true),
+    cuttlefish_unit:assert_config(Config, "lager.crash_log", "/var/log/crashy.log"),
+    cuttlefish_unit:assert_config(Config, "lager.crash_log_msg_size", 1024),
+    cuttlefish_unit:assert_config(Config, "lager.crash_log_size", 2048),
+    cuttlefish_unit:assert_config(Config, "lager.crash_log_date", "$W0"),
+    cuttlefish_unit:assert_config(Config, "lager.crash_log_count", 0),
+    cuttlefish_unit:assert_config(Config, "lager.error_logger_redirect", false),
+    cuttlefish_unit:assert_config(Config, "lager.error_logger_hwm", 50),
+    cuttlefish_unit:assert_config(Config, "vm_args.-setcookie", "tyktorp"),
+    ok.
+
+crash_log_test() ->
+    Conf = [{["log", "crash"], off}],
+    Config = cuttlefish_unit:generate_templated_config(
+               ["../../../rel/files/riak.schema"], Conf, context()),
+    cuttlefish_unit:assert_config(Config, "lager.crash_log", undefined),
+    ok.
+
+devrel_test() ->
+    RelConfig = cuttlefish_unit:generate_templated_config(
+                  ["../../../rel/files/riak.schema",
+                  "../../../deps/eleveldb/priv/eleveldb.schema"],
+                  [], context()),
+
+    cuttlefish_unit:assert_config(RelConfig, "eleveldb.limited_developer_mem", false),
+    cuttlefish_unit:assert_not_configured(RelConfig, "vm_args.-shutdown_time"),
+
+    DevRelConfig = cuttlefish_unit:generate_templated_config(
+                     ["../../../rel/files/riak.schema",
+                      "../../../deps/eleveldb/priv/eleveldb.schema"], [],
+                     lists:keyreplace(devrel, 1, context(), {devrel, true})),
+    cuttlefish_unit:assert_config(DevRelConfig, "eleveldb.limited_developer_mem", true),
+    cuttlefish_unit:assert_config(DevRelConfig, "vm_args.-shutdown_time", 10000),
+    ok.
+
+context() ->
+    [{console_log_default, file},
+     {platform_log_dir, "./log"},
+     {platform_data_dir, "./data"},
+     {devrel, false}].

--- a/rebar.config
+++ b/rebar.config
@@ -7,6 +7,7 @@
 {lib_dirs, ["apps/riak"]}.
 
 {erl_opts, [debug_info, fail_on_warning]}.
+{eunit_opts, [verbose]}.
 
 {erlydtl_opts, [
                 {compiler_options, [report, return, debug_info]}

--- a/rel/files/riak.schema
+++ b/rel/files/riak.schema
@@ -20,27 +20,27 @@
 %% @doc When 'log.console' is set to 'file' or 'both', the file where
 %% console messages will be logged.
 {mapping, "log.console.file", "lager.handlers", [
-  {default, "{{platform_log_dir}}/console.log"}
+  {default, "{{platform_log_dir}}/console.log"},
+  {datatype, file}
 ]}.
 
 %% @doc The file where error messages will be logged.
 {mapping, "log.error.file", "lager.handlers", [
-  {default, "{{platform_log_dir}}/error.log"}
+  {default, "{{platform_log_dir}}/error.log"},
+  {datatype, file}
 ]}.
 
 %% @doc When set to 'on', enables log output to syslog.
 {mapping, "log.syslog", "lager.handlers", [
   {default, off},
-  {datatype, {enum, [on, off]}}
+  {datatype, flag}
 ]}.
 
 {translation,
  "lager.handlers",
  fun(Conf) ->
-    SyslogHandler = case cuttlefish:conf_get("log.syslog", Conf) of
-      on ->  [{lager_syslog_backend, ["riak", daemon, info]}];
-      _ -> []
-    end,
+    SyslogHandler = [{lager_syslog_backend, ["riak", daemon, info]} ||
+                     cuttlefish:conf_get("log.syslog", Conf)],
     ErrorHandler = case cuttlefish:conf_get("log.error.file", Conf) of
       undefined -> [];
       ErrorFilename -> [{lager_file_backend, [{file, ErrorFilename},
@@ -55,10 +55,10 @@
 
     ConsoleHandler = {lager_console_backend, ConsoleLogLevel},
     ConsoleFileHandler = {lager_file_backend, [{file, ConsoleLogFile},
-                                                {level, ConsoleLogLevel},
-                                                {size, 10485760},
-                                                {date, "$D0"},
-                                                {count, 5}]},
+                                               {level, ConsoleLogLevel},
+                                               {size, 10485760},
+                                               {date, "$D0"},
+                                               {count, 5}]},
 
     ConsoleHandlers = case cuttlefish:conf_get("log.console", Conf) of
       off -> [];
@@ -71,41 +71,31 @@
   end
 }.
 
-%% SASL
-%% We should never care about this
+%% @doc Whether to enable Erlang's built-in error logger.
 {mapping, "sasl", "sasl.sasl_error_logger", [
   {default, off},
-  {datatype, {enum, [on, off]}},
+  {datatype, flag},
   {level, advanced}
 ]}.
-
-{ translation,
-  "sasl.sasl_error_logger",
-  fun(Conf) ->
-    case cuttlefish:conf_get("sasl", Conf) of
-        on -> true;
-        _ -> false
-    end
-  end
-}.
 
 %% @doc Whether to enable the crash log.
 {mapping, "log.crash", "lager.crash_log", [
   {default, on},
-  {datatype, {enum, [on, off]}}
+  {datatype, flag}
 ]}.
 
 %% @doc If the crash log is enabled, the file where its messages will
 %% be written.
 {mapping, "log.crash.file", "lager.crash_log", [
-  {default, "{{platform_log_dir}}/crash.log"}
+  {default, "{{platform_log_dir}}/crash.log"},
+  {datatype, file}
 ]}.
 
 {translation,
  "lager.crash_log",
  fun(Conf) ->
      case cuttlefish:conf_get("log.crash", Conf) of
-         off -> undefined;
+         false -> undefined;
          _ ->
              cuttlefish:conf_get("log.crash.file", Conf, "{{platform_log_dir}}/crash.log")
      end
@@ -155,22 +145,13 @@
     end
  end}.
 
-%% @doc Whether to redirect error_logger messages into lager - defaults to true
+%% @doc Whether to redirect error_logger messages into lager -
+%% defaults to true
 {mapping, "log.error.redirect", "lager.error_logger_redirect", [
   {default, on},
-  {datatype, {enum, [on, off]}},
+  {datatype, flag},
   {level, advanced}
 ]}.
-
-{ translation,
-  "lager.error_logger_redirect", fun(Conf) ->
-    Setting = cuttlefish:conf_get("log.error.redirect", Conf),
-    case Setting of
-      on -> true;
-      off -> false;
-      _Default -> true
-    end
-end}.
 
 %% @doc Maximum number of error_logger messages to handle in a second
 {mapping, "log.error.messages_per_second", "lager.error_logger_hwm", [
@@ -180,8 +161,9 @@ end}.
 ]}.
 
 
-%% @doc Cookie for distributed node communication.  All nodes in the same cluster
-%% should use the same cookie or they will not be able to communicate.
+%% @doc Cookie for distributed node communication.  All nodes in the
+%% same cluster should use the same cookie or they will not be able to
+%% communicate.
 {mapping, "distributed_cookie", "vm_args.-setcookie", [
   {default, "riak"}
 ]}.


### PR DESCRIPTION
- Add datatypes to log files.
- Convert on/off enums to flags.
- Add schema tests for riak.schema.

This is the twin of basho/riak_ee#215, with the EE-specific bits removed.

---
- [x] PM approval
- [x] CSE approval
