### PR TITLE
RHS schema subs platform_log_dir, {level, advanced} -> hidden

### DIFF
--- a/rel/files/riak.schema
+++ b/rel/files/riak.schema
@@ -20,13 +20,13 @@
 %% @doc When 'log.console' is set to 'file' or 'both', the file where
 %% console messages will be logged.
 {mapping, "log.console.file", "lager.handlers", [
-  {default, "{{platform_log_dir}}/console.log"},
+  {default, "#(platform_log_dir)/console.log"},
   {datatype, file}
 ]}.
 
 %% @doc The file where error messages will be logged.
 {mapping, "log.error.file", "lager.handlers", [
-  {default, "{{platform_log_dir}}/error.log"},
+  {default, "#(platform_log_dir)/error.log"},
   {datatype, file}
 ]}.
 
@@ -75,7 +75,7 @@
 {mapping, "sasl", "sasl.sasl_error_logger", [
   {default, off},
   {datatype, flag},
-  {level, advanced}
+  hidden
 ]}.
 
 %% @doc Whether to enable the crash log.
@@ -87,7 +87,7 @@
 %% @doc If the crash log is enabled, the file where its messages will
 %% be written.
 {mapping, "log.crash.file", "lager.crash_log", [
-  {default, "{{platform_log_dir}}/crash.log"},
+  {default, "#(platform_log_dir)/crash.log"},
   {datatype, file}
 ]}.
 
@@ -150,14 +150,14 @@
 {mapping, "log.error.redirect", "lager.error_logger_redirect", [
   {default, on},
   {datatype, flag},
-  {level, advanced}
+  hidden
 ]}.
 
 %% @doc Maximum number of error_logger messages to handle in a second
 {mapping, "log.error.messages_per_second", "lager.error_logger_hwm", [
   {default, 100},
   {datatype, integer},
-  {level, advanced}
+  hidden
 ]}.
 
 

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -17,9 +17,6 @@
 {pb_ip,             "127.0.0.1"}.
 {pb_port,           8087}.
 {storage_backend,   "bitcask"}.
-{ring_state_dir,    "{{platform_data_dir}}/ring"}.
-{bitcask_data_root, "{{platform_data_dir}}/bitcask"}.
-{leveldb_data_root, "{{platform_data_dir}}/leveldb"}.
 {sasl_error_log,    "{{platform_log_dir}}/sasl-error.log"}.
 {sasl_log_dir,      "{{platform_log_dir}}/sasl"}.
 
@@ -62,6 +59,5 @@
 %%
 %% yokozuna
 %%
-{yz_dir, "{{platform_data_dir}}/yz"}.
 {yz_solr_port, 8093}.
 {yz_solr_jmx_port, 8985}.

--- a/rel/vars/dev_vars.config.src
+++ b/rel/vars/dev_vars.config.src
@@ -18,10 +18,7 @@
 {handoff_port,      @HANDOFFPORT@}.
 {pb_ip,             "127.0.0.1"}.
 {pb_port,           @PBPORT@}.
-{ring_state_dir,    "{{platform_data_dir}}/ring"}.
 {storage_backend,   "bitcask"}.
-{bitcask_data_root, "{{platform_data_dir}}/bitcask"}.
-{leveldb_data_root, "{{platform_data_dir}}/leveldb"}.
 {sasl_error_log,    "{{platform_log_dir}}/sasl-error.log"}.
 {sasl_log_dir,      "{{platform_log_dir}}/sasl"}.
 
@@ -64,6 +61,5 @@
 %%
 %% yokozuna
 %%
-{yz_dir, "{{platform_data_dir}}/yz"}.
 {yz_solr_port, @YZSOLRPORT@}.
 {yz_solr_jmx_port, @YZSOLRJMXPORT@}.


### PR DESCRIPTION
This PR is to handle two overall cuttlefish related changes:
#### replacing `{level, advanced}` with `hidden`

`{level, advanced}` was getting confused with the `advanced.config` file. basho/cuttlefish#120 added a synonym for `{level, advanced}` called `hidden` and we migrated the riak.schema to that format.
#### Right Hand Side (RHS) substitutions for platform_*_dir

Riak's overall configuration was inconsistent when it came to relative directories. basho/cuttlefish#116 added the ability to set one configuration setting relative to another. So if you change the "parent" setting, the child (if left to it's default) would also change.

For example, changing `platform_log_dir` will change the default location of both `console.log` and `error.log`

Requires:
- [x] Eng +1
- [x] CSE +1
- [x] ProdMgmt +1
