### PR TITLE
Treat users and groups as distinct concepts

### DIFF
--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -216,6 +216,9 @@ security_admin()
         print-users)
             $NODETOOL rpc riak_core_console print_users
             ;;
+        print-groups)
+            $NODETOOL rpc riak_core_console print_groups
+            ;;
         print-sources)
             $NODETOOL rpc riak_core_console print_sources
             ;;
@@ -235,6 +238,14 @@ security_admin()
                 exit 1
             fi
             $NODETOOL rpc riak_core_console print_user "$@"
+            ;;
+        print-group)
+            shift
+            if [ $# -lt 1 ]; then
+                echo "Usage: $SCRIPT security print-group <group>"
+                exit 1
+            fi
+            $NODETOOL rpc riak_core_console print_group "$@"
             ;;
         ciphers)
             shift

--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -247,8 +247,11 @@ Usage: $SCRIPT security <command>
 The following commands modify users and security ACLs for Riak:
 
     add-user <username> [<option>=<value> [...]]
+    add-group <groupname> [<option>=<value> [...]]
     alter-user <username> <option> [<option>=<value> [...]]
+    alter-group <groupname> <option> [<option>=<value> [...]]
     del-user <username>
+    del-group <groupname>
     add-source all|<users> <CIDR> <source> [<option>=<value> [...]]
     del-source all|<users> <CIDR>
     grant <permissions> ON ANY|<type> [bucket] TO <users>

--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -268,8 +268,10 @@ The following commands modify users and security ACLs for Riak:
     grant <permissions> ON ANY|<type> [bucket] TO <users>
     revoke <permissions> ON ANY|<type> [bucket] FROM <users>
     print-users
-    print-sources
+    print-groups
     print-user <user>
+    print-group <group>
+    print-sources
     enable
     disable
     status

--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -141,6 +141,14 @@ security_admin()
             fi
             $NODETOOL rpc riak_core_console add_user "$@"
             ;;
+        add-group)
+            shift
+            if [ $# -lt 1 ]; then
+                echo "Usage: $SCRIPT security add-group <group> [<option>=<value> [...]]"
+                exit 1
+            fi
+            $NODETOOL rpc riak_core_console add_group "$@"
+            ;;
         alter-user)
             shift
             if [ $# -lt 2 ]; then
@@ -149,13 +157,29 @@ security_admin()
             fi
             $NODETOOL rpc riak_core_console alter_user "$@"
             ;;
+        alter-group)
+            shift
+            if [ $# -lt 2 ]; then
+                echo "Usage: $SCRIPT security alter-group <group> <option> [<option>=<value> [...]]"
+                exit 1
+            fi
+            $NODETOOL rpc riak_core_console alter_group "$@"
+            ;;
         del-user)
             shift
             if [ $# -ne 1 ]; then
-                echo "Usage: $SCRIPT security alter-user <user>"
+                echo "Usage: $SCRIPT security del-user <user>"
                 exit 1
             fi
             $NODETOOL rpc riak_core_console del_user "$@"
+            ;;
+        del-group)
+            shift
+            if [ $# -ne 1 ]; then
+                echo "Usage: $SCRIPT security del-group <user>"
+                exit 1
+            fi
+            $NODETOOL rpc riak_core_console del_group "$@"
             ;;
         add-source)
             shift


### PR DESCRIPTION
To make it easier to reason about and document the new security behavior, this PR splits roles into users and groups.
- Users (but not groups) can be given authentication information (sources).
- Groups (but not users) can be used to cascade privileges to other groups and users.

Where the code does not or cannot distinguish between users and groups, I continue to refer to roles, but the user interface is constrained to users and groups.

There are 3 projects impacted by this change, all with the same branch name (`jrd-security-role-bifurcation`):
- riak
- riak_core
- riak_test

All should be merged at the same time. I will be filing PRs for each.

/cc @Vagabond
