### PR TITLE
No longer need all caps for keywords in grant/revoke commands

### DIFF
--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -212,7 +212,7 @@ security_admin()
         grant)
             shift
             if [ $# -lt 5 ]; then
-                echo "Usage: $SCRIPT security grant <permissions> ON ANY|<type> [bucket] TO <users>"
+                echo "Usage: $SCRIPT security grant <permissions> on any|<type> [bucket] to <users>"
                 exit 1
             fi
             $NODETOOL rpc riak_core_console grant "$@"
@@ -220,7 +220,7 @@ security_admin()
         revoke)
             shift
             if [ $# -lt 5 ]; then
-                echo "Usage: $SCRIPT security revoke <permissions> ON ANY|<type> [bucket] FROM <users>"
+                echo "Usage: $SCRIPT security revoke <permissions> on any|<type> [bucket] from <users>"
                 exit 1
             fi
             $NODETOOL rpc riak_core_console revoke "$@"
@@ -287,8 +287,8 @@ The following commands modify users and security ACLs for Riak:
     del-group <groupname>
     add-source all|<users> <CIDR> <source> [<option>=<value> [...]]
     del-source all|<users> <CIDR>
-    grant <permissions> ON ANY|<type> [bucket] TO <users>
-    revoke <permissions> ON ANY|<type> [bucket] FROM <users>
+    grant <permissions> on any|<type> [bucket] to <users>
+    revoke <permissions> on any|<type> [bucket] from <users>
     print-users
     print-groups
     print-user <user>


### PR DESCRIPTION
Tied to a forthcoming PR in `riak_core`.

/cc @Vagabond 
