### PR TITLE
Update runner_ulimit_warn to a reasonable number

### DIFF
--- a/rel/vars.config
+++ b/rel/vars.config
@@ -49,6 +49,7 @@
 {pipe_dir,           "/tmp/$RUNNER_BASE_DIR/"}.
 {runner_user,        ""}.
 {runner_wait_process, "riak_core_node_watcher"}.
+{runner_ulimit_warn, 65536}.
 
 %%
 %% cuttlefish


### PR DESCRIPTION
This updates the default runner_ulimit_warn from 4096 to 65536, which is much closer to what we recommend (very high or unlimited). Currently, anyone setting to the recommended 4096 is going to have a bad time.

Changes this:

```
!!!!
!!!! WARNING: ulimit -n is 1024; 4096 is the recommended minimum.
!!!!
```

To this:

```
!!!!
!!!! WARNING: ulimit -n is 1024; 65536 is the recommended minimum.
!!!!
```

Btw, this is prime bikeshedding material.

I'll add this into basho/riak_ee after some +1s
