### PR TITLE
Add switch-to-new-search command

### DIFF
--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -319,6 +319,18 @@ search_admin()
 
             $NODETOOL rpc yz_console aae_status "$@"
             ;;
+        switch[_-]to[_-]new[_-]search)
+            if [ $# -ne 1 ]; then
+                echo "Usage: $SCRIPT search $1"
+                exit 1
+            fi
+            shift
+
+            # Make sure the local node is running
+            node_up_check
+
+            $NODETOOL rpc yz_console switch_to_new_search "$@"
+            ;;
         *)
 echo "\
 Usage: $SCRIPT search <command>
@@ -326,6 +338,7 @@ Usage: $SCRIPT search <command>
 Available commands:
 
     aae-status
+    switch-to-new-search
 "
     esac
 }


### PR DESCRIPTION
Add the switch-to-new-search command under the search command. This is
used when migrating from legacy riak_search to yokozuna. It does a
multicall across the cluster handing over HTTP and PB control from
riak_search to yokozuna.

This is needed for issue basho/yokozuna#350.
