### PR TITLE
Add `cuttlefish_conf` to pkg.vars.config to support packaging

### DIFF
--- a/pkg.vars.config
+++ b/pkg.vars.config
@@ -21,6 +21,7 @@
 {vendor_url, "http://basho.com"}.
 {vendor_contact_name, "Basho Package Maintainer"}.
 {vendor_contact_email, "packaging@basho.com"}.
+{cuttlefish_conf, "riak.conf"}.
 {license_full_text, "This file is provided to you under the Apache License,\n"
 "Version 2.0 (the \"License\"); you may not use this file\n"
 "except in compliance with the License.  You may obtain\n"


### PR DESCRIPTION
The `cuttlefish_conf` variable was already in the vars.config
files, but that was not enough to support proper packaging
support of cuttlefish.  Many packages need to know about the
config files that are being installed on the system and the
vars.config template variables are not available to files outside
of the ones overlayed in the reltool.config.
