### PR TITLE
bucket-type create: don't require empty json for default props

### DIFF
--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -323,12 +323,13 @@ btype_admin()
             $NODETOOL rpc riak_kv_console bucket_type_activate "$2"
             ;;
         create)
-            if [ $# -ne 3 ]; then
-                echo "Usage: $SCRIPT bucket-type create <type> '{\"props\": { ... }}'"
+            if [ $# -lt 2 ]; then
+                echo "Usage: $SCRIPT bucket-type create <type> ['{\"props\": { ... }}']"
                 exit 1
             fi
             node_up_check
-            $NODETOOL rpc riak_kv_console bucket_type_create "$2" "$3"
+            json=${3:-}
+            $NODETOOL rpc riak_kv_console bucket_type_create "$2" "$json"
             ;;
         update)
             if [ $# -ne 3 ]; then


### PR DESCRIPTION
- [ ] apply to `riak_ee`

depends on https://github.com/basho/riak_kv/pull/868

addresses https://github.com/basho/riak/issues/423
