### PR TITLE
bucket-type create: don't require empty json for default props

### DIFF
--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -350,8 +350,8 @@ btype_admin()
             $NODETOOL rpc riak_kv_console bucket_type_activate "$2"
             ;;
         create)
-            if [ $# -lt 3 ]; then
-                echo "Usage: $SCRIPT bucket-type create <type> '{\"props\": { ... }}'"
+            if [ $# -lt 2 ]; then
+                echo "Usage: $SCRIPT bucket-type create <type> ['{\"props\": { ... }}']"
                 exit 1
             fi
             node_up_check
@@ -360,8 +360,9 @@ btype_admin()
             #     bucket-type create <type> '{"props": { ... }}'"
             #     bucket-type create <type> {"props": { ... }}"
             #
-            if [ $# -eq 3 ]; then
-                $NODETOOL rpc riak_kv_console bucket_type_create "$2" "$3"
+            if [ $# -le 3 ]; then
+                json=${3:-}
+                $NODETOOL rpc riak_kv_console bucket_type_create "$2" "$json"
             else  # greater than 3 parameters
                 two=$2
                 shift 2


### PR DESCRIPTION
- [x] apply to `riak_ee` - https://github.com/basho/riak_ee/pull/246
- replaces https://github.com/basho/riak/pull/531
- depends on  basho/riak_kv#868
- addresses #423
