### PR TITLE
Update rebar.config to restrict erlang version to R16

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 {sub_dirs, ["rel", "apps/riak"]}.
 
-{require_otp_vsn, "R14B0[234]|R15|R16"}.
+{require_otp_vsn, "R16"}.
 {cover_enabled, true}.
 
 {lib_dirs, ["apps/riak"]}.


### PR DESCRIPTION
The latest development has been against R16 and the `HEAD` of `develop` no
longer builds with versions less than R16. [Cuttlefish](https://github.com/basho/cuttlefish/blob/develop/rebar.config#L1) explicitly requires R16 or R17 and all 2.0 development was done against R16 so it is a good idea to be explicit at the top-level.
- [x] Update riak_ee repo with this change
