### PR TITLE
Change DEVNODES=5 to DEVNODES=8 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ relclean:
 ##    make stagedevrel DEVNODES=68
 
 .PHONY : stagedevrel devrel
-DEVNODES ?= 5
+DEVNODES ?= 8
 
 # 'seq' is not available on all *BSD, so using an alternate in awk
 SEQ = $(shell awk 'BEGIN { for (i = 1; i < '$(DEVNODES)'; i++) printf("%i ", i); print i ;exit(0);}')


### PR DESCRIPTION
Some SC tests require 8 nodes. Therefore raise the default to prevent
spurious errors.
