### PR TITLE
Add syslog parameters to the Riak schema

### DIFF
--- a/apps/riak/test/riak_schema_test.erl
+++ b/apps/riak/test/riak_schema_test.erl
@@ -74,6 +74,28 @@ override_schema_test() ->
     cuttlefish_unit:assert_config(Config, "vm_args.-setcookie", "tyktorp"),
     ok.
 
+custom_syslog_test() ->
+    Conf = [{["log", "syslog"], on},
+            {["log","syslog","ident"], "VeryCool"},
+            {["log","syslog","facility"], local4},
+            {["log","syslog","level"], warning}],
+    Config = cuttlefish_unit:generate_templated_config(
+               ["../../../rel/files/riak.schema"], Conf, context(), predefined_schema()),
+    cuttlefish_unit:assert_config(Config, "lager.handlers",
+                                  [{lager_syslog_backend, ["VeryCool", local4, warning]},
+                                   {lager_file_backend, [{file, "./log/console.log"},
+                                                         {level, info},
+                                                         {size, 10485760},
+                                                         {date, "$D0"},
+                                                         {count, 5}]},
+                                   {lager_file_backend, [{file, "./log/error.log"},
+                                                         {level, error},
+                                                         {size, 10485760},
+                                                         {date, "$D0"},
+                                                         {count, 5}]}
+                                  ]),
+    ok.
+
 crash_log_test() ->
     Conf = [{["log", "crash"], off}],
     Config = cuttlefish_unit:generate_templated_config(

--- a/rel/files/riak.schema
+++ b/rel/files/riak.schema
@@ -14,7 +14,7 @@
 %% @doc The severity level of the console log, default is 'info'.
 {mapping, "log.console.level", "lager.handlers", [
   {default, info},
-  {datatype, {enum, [debug, info, warning, error]}}
+  {datatype, {enum, [debug, info, notice, warning, error, critical, alert, emergency, none]}}
 ]}.
 
 %% @doc When 'log.console' is set to 'file' or 'both', the file where
@@ -36,11 +36,40 @@
   {datatype, flag}
 ]}.
 
+%% @doc When set to 'on', enables log output to syslog.
+{mapping, "log.syslog.ident", "lager.handlers", [
+  {default, "riak"},
+  hidden
+]}.
+
+%% @doc Syslog facility to log entries from Riak.
+{mapping, "log.syslog.facility", "lager.handlers", [
+  {default, daemon},
+  {datatype, {enum,[kern, user, mail, daemon, auth, syslog,
+                    lpr, news, uucp, clock, authpriv, ftp,
+                    cron, local0, local1, local2, local3,
+                    local4, local5, local6, local7]}},
+  hidden
+]}.
+
+%% @doc The severity level at which to log entries to syslog, default is 'info'.
+{mapping, "log.syslog.level", "lager.handlers", [
+  {default, info},
+  {datatype, {enum, [debug, info, notice, warning, error, critical, alert, emergency, none]}},
+  hidden
+]}.
+
 {translation,
  "lager.handlers",
  fun(Conf) ->
-    SyslogHandler = [{lager_syslog_backend, ["riak", daemon, info]} ||
-                     cuttlefish:conf_get("log.syslog", Conf)],
+    SyslogHandler = case cuttlefish:conf_get("log.syslog", Conf) of
+      true ->
+        Ident = cuttlefish:conf_get("log.syslog.ident", Conf),
+        Facility = cuttlefish:conf_get("log.syslog.facility", Conf),
+        LogLevel = cuttlefish:conf_get("log.syslog.level", Conf),
+        [{lager_syslog_backend, [Ident, Facility, LogLevel]}];
+      _ -> []
+    end,
     ErrorHandler = case cuttlefish:conf_get("log.error.file", Conf) of
       undefined -> [];
       ErrorFilename -> [{lager_file_backend, [{file, ErrorFilename},
@@ -70,6 +99,7 @@
     SyslogHandler ++ ConsoleHandlers ++ ErrorHandler
   end
 }.
+
 
 %% @doc Whether to enable Erlang's built-in error logger.
 {mapping, "sasl", "sasl.sasl_error_logger", [


### PR DESCRIPTION
Enables users to customize ident, facility, and loglevel.
