### PR TITLE
riak-debug - check /etc/default/riak (ulimit should be set there)

### DIFF
--- a/rel/files/riak-debug
+++ b/rel/files/riak-debug
@@ -373,6 +373,8 @@ if [ 1 -eq $get_syscmds ]; then
 
     # Dump files
     [ -f /etc/release ] && dump release cat /etc/release
+    [ -f /etc/default/riak ] && dump etc_default_riak cat /etc/default/riak
+    [ ! -f /etc/default/riak ] && dump etc_default_riak echo "error: /etc/default/riak missing"
     [ -f /etc/redhat-release ] && dump redhat_release cat /etc/redhat-release
     [ -f /etc/debian_version ] && dump debian_version cat /etc/debian_version
     [ -f /etc/security/limits.conf ] && dump limits.conf cat /etc/security/limits.conf


### PR DESCRIPTION
http://docs.basho.com/riak/1.4.10/ops/tuning/open-files-limit/#Linux

It is very common for Ubuntu users to forget to set ulimit -n 66xxx in /etc/default/riak 

This adds an additional check for this file to riak-debug 
