### PR TITLE
Remove afunix from EXOMETER_PACKAGES.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ OVERLAY_VARS    ?=
 RIAK_CORE_STAT_PREFIX = riak
 export RIAK_CORE_STAT_PREFIX
 
-EXOMETER_PACKAGES = "(basic), +afunix"
+EXOMETER_PACKAGES = "(basic)"
 export EXOMETER_PACKAGES
 
 $(if $(ERLANG_BIN),,$(warning "Warning: No Erlang found in your path, this will probably not work"))


### PR DESCRIPTION
Afunix is not used at this time, and may cause build issues on some
platforms.
