### PR TITLE
remove afunix from reltool.config

### DIFF
--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -28,7 +28,6 @@
          cluster_info,
          riak_control,
          exometer,
-         afunix,
          erlydtl,
          riak_auth_mods,
          {folsom, load},
@@ -64,7 +63,6 @@
        {app, lager, [{incl_cond, include}]},
        {app, riak_control, [{incl_cond, include}]},
        {app, exometer, [{incl_cond, include}]},
-       {app, afunix, [{incl_cond, include}]},
        {app, riak_api, [{incl_cond, include}]},
        {app, folsom, [{incl_cond, include}]},
        {app, riak_ensemble, [{incl_cond, include}]}


### PR DESCRIPTION
When removing 'afunix' from the Makefile, mentions of afunix where left behind in reltool.config. Since the Makefile instruction triggered fetching of the afunix dependency, `rebar generate` would fail.

This change has been verified by running `make devrel DEVNODES=1`. Afunix is not used in riak at this time, so removing it is deliberate and unproblematic - it was just incompletely done.
