### PR TITLE
Pass flags through to the cluster status CLI command

### DIFF
--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -307,7 +307,7 @@ cluster_admin()
             ;;
         status)
             node_up_check
-            $NODETOOL rpc riak_core_console command $SCRIPT cluster status
+            $NODETOOL rpc riak_core_console command $SCRIPT cluster $@
             ;;
         partitions|partition)
             node_up_check


### PR DESCRIPTION
This allows us to use the --help/--format flags on the cluster status command (and whatever other future flags may be implemented). Clique will filter out any invalid flags and display appropriate error messages anyway, so we don't need to be managing that in the riak-admin script.
