### PR TITLE
Updating rebar.config to be set purely to tags/SHAs

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,16 +14,16 @@
                ]}.
 
 {deps, [
-        {node_package, ".*", {git, "git://github.com/basho/node_package.git", {branch, "develop"}}},
-        {lager_syslog, "2.0.3", {git, "git://github.com/basho/lager_syslog.git", {tag, "2.0.3"}}},
-        {cluster_info, ".*", {git, "git://github.com/basho/cluster_info.git", {branch, "develop"}}},
-        {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {branch, "develop"}}},
-        {riak_search, ".*", {git, "git://github.com/basho/riak_search.git", {branch, "develop"}}},
-        {riak_control, ".*", {git, "git://github.com/basho/riak_control.git", {branch, "develop"}}},
+        {node_package, ".*", {git, "git://github.com/basho/node_package.git", {tag, "2.0.0"}}},
+        {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog.git", {tag, "2.0.3"}}},
+        {cluster_info, ".*", {git, "git://github.com/basho/cluster_info.git", {tag, "2.0.0"}}},
+        {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {tag, "2.0.2"}}},
+        {riak_search, ".*", {git, "git://github.com/basho/riak_search.git", {tag, "2.0.0"}}},
+        {riak_control, ".*", {git, "git://github.com/basho/riak_control.git", {tag, "2.0.0"}}},
         {riaknostic, ".*", {git, "git://github.com/basho/riaknostic.git", {tag, "2.0.0"}}},
-        {yokozuna, ".*", {git, "git://github.com/basho/yokozuna.git", {branch, "develop"}}},
-        {riak_auth_mods, ".*", {git, "git://github.com/basho/riak_auth_mods.git", {branch, "develop"}}},
-        {rebar_lock_deps_plugin, ".*", {git, "git://github.com/seth/rebar_lock_deps_plugin.git", {branch, "master"}}}
+        {yokozuna, ".*", {git, "git://github.com/basho/yokozuna.git", {tag, "2.0.0"}}},
+        {riak_auth_mods, ".*", {git, "git://github.com/basho/riak_auth_mods.git", {tag, "2.0.0"}}},
+        {rebar_lock_deps_plugin, ".*", {git, "git://github.com/seth/rebar_lock_deps_plugin.git", {tag, "3.1.0"}}}
        ]}.
 
 {plugins, [rebar_lock_deps_plugin]}.


### PR DESCRIPTION
As requested following conversations with Andrew Stone, here's a PR to pin deps to the latest tags available in subrepos. Be aware that work may be needed in those subrepos to actually bring in commits that are expected, as previous builds have been against branches.
