### PR TITLE
Pin meck dependency at top-level Riak.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,7 +23,8 @@
         {riaknostic, ".*", {git, "git://github.com/basho/riaknostic.git", {tag, "2.0.0"}}},
         {yokozuna, ".*", {git, "git://github.com/basho/yokozuna.git", {branch, "develop"}}},
         {riak_auth_mods, ".*", {git, "git://github.com/basho/riak_auth_mods.git", {branch, "develop"}}},
-        {rebar_lock_deps_plugin, ".*", {git, "git://github.com/seth/rebar_lock_deps_plugin.git", {branch, "master"}}}
+        {rebar_lock_deps_plugin, ".*", {git, "git://github.com/seth/rebar_lock_deps_plugin.git", {branch, "master"}}},
+        {meck, "0.8.1", {git, "git://github.com/basho/meck.git", {tag, "0.8.1"}}}
        ]}.
 
 {plugins, [rebar_lock_deps_plugin]}.


### PR DESCRIPTION
This prevents situtations whre we have a race between libraries with
dependencies to see who pulls in meck, at what version, first.
