### PR TITLE
Make sure that locked deps are obeyed for packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ get_dist_deps = mkdir distdir && \
                 git clone . distdir/$(CLONEDIR) && \
                 cd distdir/$(CLONEDIR) && \
                 git checkout $(REPO_TAG) && \
-                $(MAKE) deps && \
+                $(MAKE) locked-deps && \
                 echo "- Dependencies and their tags at build time of $(REPO) at $(REPO_TAG)" > $(MANIFEST_FILE) && \
                 for dep in deps/*; do \
                     cd $${dep} && \


### PR DESCRIPTION
Make sure that Make calls rebar appropriately.

To test:
To test:
- Run make package! Observe output.
- Make sure that you don't see something like the below (as in previous builds)

> make[1]: Entering directory `/home/whatever'
> ./rebar get-deps

but instead

> ./rebar -C rebar.config.lock get-deps
