### PR TITLE
Always start xmerl

### DIFF
--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -15,6 +15,7 @@
          crypto,
          runtime_tools,
          erlang_js,
+         xmerl,
          mochiweb,
          webmachine,
          basho_stats,


### PR DESCRIPTION
Right now the xmerl application is sometimes (but not always) started from code within Riak. This change makes it consistent, so that it's always started. This way we always see xmerl_version show up in the stats, which helps when we're trying to verify stats in riak_test.

(Incidentally, xmerl can be used without starting the xmerl application, as the xmerl application really doesn't do anything. It's just a placeholder, so there's not really any disadvantage to starting it.)
