### PR TITLE
Riak and Riak_EE can have the same riak-debug

### DIFF
--- a/rel/files/riak-debug
+++ b/rel/files/riak-debug
@@ -480,6 +480,9 @@ if [ 1 -eq $get_riakcmds ]; then
     dump riak_search_aae_status "$riak_bin_dir"/riak-admin search aae-status
     dump riak_diag "$riak_bin_dir"/riak-admin diag
     dump riak_repl_status "$riak_bin_dir"/riak-repl status
+    dump riak_repl_connections "$riak_bin_dir"/riak-repl connections
+    dump riak_repl_clusterstats "$riak_bin_dir"/riak-repl clusterstats
+    dump riak_repl_modes "$riak_bin_dir"/riak-repl modes
 
     CI=`pwd`/cluster-info.html
     touch $CI


### PR DESCRIPTION
Because of the way `dump` is written, there's no harm in including
`riak-repl` commands in Riak's `riak-debug`. With that in mind,
there's no reason to maintain two separate versions of `riak-debug`.
