### PR TITLE
Apply fix for basho/riak_core#670 to devrel

### DIFF
--- a/rel/vars/dev_vars.config.src
+++ b/rel/vars/dev_vars.config.src
@@ -16,6 +16,7 @@
 {web_ip,            "127.0.0.1"}.
 {web_port,          @WEBPORT@}.
 {handoff_port,      @HANDOFFPORT@}.
+{handoff_ip,        "127.0.0.1"}.
 {pb_ip,             "127.0.0.1"}.
 {pb_port,           @PBPORT@}.
 {storage_backend,   "bitcask"}.


### PR DESCRIPTION
See also:

https://github.com/basho/riak_core/issues/670

Without this change, I get the `handoff.ip` error trying to start a devrel node from a fresh `riak-2.1.0` tag build.
