### PR TITLE
Make default handoff_ip value 0.0.0.0 in vars.config

### DIFF
--- a/rel/vars.config
+++ b/rel/vars.config
@@ -14,7 +14,7 @@
 {web_ip,            "127.0.0.1"}.
 {web_port,          8098}.
 {handoff_port,      8099}.
-{handoff_ip,        "127.0.0.1"}.
+{handoff_ip,        "0.0.0.0"}.
 {pb_ip,             "127.0.0.1"}.
 {pb_port,           8087}.
 {storage_backend,   "bitcask"}.

--- a/rel/vars/dev_vars.config.src
+++ b/rel/vars/dev_vars.config.src
@@ -15,6 +15,7 @@
 %%
 {web_ip,            "127.0.0.1"}.
 {web_port,          @WEBPORT@}.
+{handoff_ip,        "127.0.0.1"}.
 {handoff_port,      @HANDOFFPORT@}.
 {pb_ip,             "127.0.0.1"}.
 {pb_port,           @PBPORT@}.


### PR DESCRIPTION
so nodes don’t hand off to themselves in production clusters. Also update dev_vars.config.src to set handoff_ip to 127.0.0.1 for devrel builds.
