### PR TITLE
Bugfix/2.1.1 use locked deps for dist and fix deps to 2.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ test: deps compile testclean
 ##
 ## Release targets
 ##
-rel: deps compile generate
+rel: locked-deps compile generate
 
 relclean:
 	rm -rf rel/riak

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ get_dist_deps = mkdir distdir && \
                 git clone . distdir/$(CLONEDIR) && \
                 cd distdir/$(CLONEDIR) && \
                 git checkout $(REPO_TAG) && \
-                $(MAKE) deps && \
+                $(MAKE) locked-deps && \
                 echo "- Dependencies and their tags at build time of $(REPO) at $(REPO_TAG)" > $(MANIFEST_FILE) && \
                 for dep in deps/*; do \
                     cd $${dep} && \

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,14 @@
+# Riak 2.1.1 Release Notes
+
+## Critical Fixes
+
+* Default IP address for inbound handoff connections (riak.conf setting handoff.ip) has been
+  reverted to 0.0.0.0.  The 2.1.0 release picked up a setting intended for devrel clusters
+  only.
+
+  This resolves Basho Product Advisory - Riak 2.1.0: Default Configuration For Handoff
+  May Cause Data Loss
+
 # Riak 2.1.0 Release Notes
 
 ## New Features

--- a/rebar.config.lock
+++ b/rebar.config.lock
@@ -147,7 +147,7 @@
                      "e8ae353c16d4f0897abb9f80025b52925b974dd1"}},
        {yokozuna,".*",
                  {git,"git://github.com/basho/yokozuna.git",
-                      "cb41c27b82b7d79a7349f5b79d7dbe485b63d852"}},
+                      "52b7d7235314fb3e5eab2bc3f1d38345d3dd0b35"}},
        {canola,".*",
                {git,"git://github.com/basho/canola.git",
                     "9bdfee88fce20b3a01b7003696b53eb21913d6fb"}},

--- a/rebar.config.lock
+++ b/rebar.config.lock
@@ -147,7 +147,7 @@
                      "e8ae353c16d4f0897abb9f80025b52925b974dd1"}},
        {yokozuna,".*",
                  {git,"git://github.com/basho/yokozuna.git",
-                      "52b7d7235314fb3e5eab2bc3f1d38345d3dd0b35"}},
+                      "cb41c27b82b7d79a7349f5b79d7dbe485b63d852"}},
        {canola,".*",
                {git,"git://github.com/basho/canola.git",
                     "9bdfee88fce20b3a01b7003696b53eb21913d6fb"}},


### PR DESCRIPTION
Apply the build fix to use locked-deps when building the release tarball/packages that was applied to 2.0 after it diverged from master (needs to be added to develop too). Otherwise the rebar.config settings are used.

Reconstruct the locked deps as of the released 2.1.0 tarball so that the 2.1.1 release only differs in the top level packaging to pick up the handoff.ip changes for cuttelfish.

Companion PR to basho/riak_ee#334
