### PR TITLE
Fix issues with scripts when CDPATH is set

### DIFF
--- a/rel/vars.config
+++ b/rel/vars.config
@@ -41,7 +41,7 @@
 %%
 %% bin/riak
 %%
-{runner_script_dir,  "\`cd \\`dirname $0\\` && /bin/pwd\`"}.
+{runner_script_dir,  "\`cd \\`dirname $0\\` 1>&- && /bin/pwd\`"}.
 {runner_base_dir,    "{{runner_script_dir}}/.."}.
 {runner_etc_dir,     "$RUNNER_BASE_DIR/etc"}.
 {runner_log_dir,     "$RUNNER_BASE_DIR/log"}.

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -41,7 +41,7 @@
 %%
 %% bin/riak
 %%
-{runner_script_dir,  "\`cd \\`dirname $0\\` 1>&- && /bin/pwd\`"}.
+{runner_script_dir,  "\`cd \\`dirname $0\\` 1>/dev/null && /bin/pwd\`"}.
 {runner_base_dir,    "{{runner_script_dir}}/.."}.
 {runner_etc_dir,     "$RUNNER_BASE_DIR/etc"}.
 {runner_log_dir,     "$RUNNER_BASE_DIR/log"}.

--- a/rel/vars/dev_vars.config.src
+++ b/rel/vars/dev_vars.config.src
@@ -42,7 +42,7 @@
 %%
 %% bin/riak
 %%
-{runner_script_dir,  "\`cd \\`dirname $0\\` 1>&- && /bin/pwd\`"}.
+{runner_script_dir,  "\`cd \\`dirname $0\\` 1>/dev/null && /bin/pwd\`"}.
 {runner_base_dir,    "{{runner_script_dir}}/.."}.
 {runner_etc_dir,     "$RUNNER_BASE_DIR/etc"}.
 {runner_log_dir,     "$RUNNER_BASE_DIR/log"}.

--- a/rel/vars/dev_vars.config.src
+++ b/rel/vars/dev_vars.config.src
@@ -42,7 +42,7 @@
 %%
 %% bin/riak
 %%
-{runner_script_dir,  "\`cd \\`dirname $0\\` && /bin/pwd\`"}.
+{runner_script_dir,  "\`cd \\`dirname $0\\` 1>&- && /bin/pwd\`"}.
 {runner_base_dir,    "{{runner_script_dir}}/.."}.
 {runner_etc_dir,     "$RUNNER_BASE_DIR/etc"}.
 {runner_log_dir,     "$RUNNER_BASE_DIR/log"}.

--- a/rel/vars/perf_vars.config.src
+++ b/rel/vars/perf_vars.config.src
@@ -49,7 +49,7 @@
 %%
 %% bin/riak
 %%
-{runner_script_dir,  "\`cd \\`dirname $0\\` && /bin/pwd\`"}.
+{runner_script_dir,  "\`cd \\`dirname $0\\` 1>&- && /bin/pwd\`"}.
 {runner_base_dir,    "{{runner_script_dir}}/.."}.
 {runner_etc_dir,     "$RUNNER_BASE_DIR/etc"}.
 {runner_log_dir,     "$RUNNER_BASE_DIR/log"}.

--- a/rel/vars/perf_vars.config.src
+++ b/rel/vars/perf_vars.config.src
@@ -49,7 +49,7 @@
 %%
 %% bin/riak
 %%
-{runner_script_dir,  "\`cd \\`dirname $0\\` 1>&- && /bin/pwd\`"}.
+{runner_script_dir,  "\`cd \\`dirname $0\\` 1>/dev/null && /bin/pwd\`"}.
 {runner_base_dir,    "{{runner_script_dir}}/.."}.
 {runner_etc_dir,     "$RUNNER_BASE_DIR/etc"}.
 {runner_log_dir,     "$RUNNER_BASE_DIR/log"}.


### PR DESCRIPTION
The CDPATH environment variable can cause the cd command to sometimes
produce output. This breaks `runner_script_dir` detection in several
scripts. This fix suppresses the output from the cd command whenever it
is produced and allows the scripts to successfully detect the correct
directory for `runner_script_dir`.

For more information on when cd might produce output, see:
http://pubs.opengroup.org/onlinepubs/9699919799/utilities/cd.html#tag_20_14_10
