### PR TITLE
backporting riak debug fix to 2.1

### DIFF
--- a/rel/files/riak-debug
+++ b/rel/files/riak-debug
@@ -860,7 +860,7 @@ if [ 1 -eq $get_cfgs ]; then
 
     # Compose the `find` command that will exclude the above list of files,
     # being aware that an empty `\( \)` will cause a failure in the `find`.
-    if [ -n $exclude ]; then
+    if [ -n "$exclude" ]; then
         run="find . -type f -exec sh -c '
                 mkdir -p \"\$0/\${1%/*}\";
                 cp \"\$1\" \"\$0/\$1\"


### PR DESCRIPTION
The `riak/rel/files/riak-debug` file throws the following error during execution: 

```
........E......EE......................dev2/bin/riak-debug: line 863: [: too many arguments
```

This error originates from the following line:

```
    if [ -n $exclude ]; then
```

To fix this, the `$exclude` must be in quotation marks as follows:

```
    if [ -n "$exclude" ]; then
```

_The fix is applied in this PR._
