### PR TITLE
update rebar config for riak for 2.1 maint branches and tag updates

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,17 +14,16 @@
                ]}.
 
 {deps, [
-        {rebar_lock_deps_plugin, ".*", {git, "git://github.com/seth/rebar_lock_deps_plugin.git", {tag, "7a5835029c42b8138325405237ea7e8516a84800"}}},
-        {node_package, ".*", {git, "git://github.com/basho/node_package.git", {tag, "2.0.2"}}},
+        {node_package, ".*", {git, "git://github.com/basho/node_package.git", {tag, "2.0.3"}}},
         {lager_syslog, "2.0.3", {git, "git://github.com/basho/lager_syslog.git", {tag, "2.0.3"}}},
-        {cluster_info, ".*", {git, "git://github.com/basho/cluster_info.git", {tag, "2.0.2"}}},
-        {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {tag, "2.1.0"}}},
-        {riak_search, ".*", {git, "git://github.com/basho/riak_search.git", {tag, "2.0.2"}}},
-        {riak_control, ".*", {git, "git://github.com/basho/riak_control.git", {tag, "2.1.1"}}},
-        {riaknostic, ".*", {git, "git://github.com/basho/riaknostic.git", {tag, "2.0.1"}}},
-        {yokozuna, ".*", {git, "git://github.com/basho/yokozuna.git", {tag, "2.1.0"}}},
-        {riak_auth_mods, ".*", {git, "git://github.com/basho/riak_auth_mods.git", {tag, "2.0.1"}}},
-        {meck, "0.8.2", {git, "git://github.com/basho/meck.git", {tag, "0.8.2"}}}
+        {cluster_info, ".*", {git, "git://github.com/basho/cluster_info.git", {tag, "2.0.3"}}},
+        {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {branch, "2.1"}}},
+        {riak_search, ".*", {git, "git://github.com/basho/riak_search.git", {branch, "2.1"}}},
+        {riak_control, ".*", {git, "git://github.com/basho/riak_control.git", {branch, "2.1"}}},
+        {riaknostic, ".*", {git, "git://github.com/basho/riaknostic.git", {branch, "2.1"}}},
+        {yokozuna, ".*", {git, "git://github.com/basho/yokozuna.git", {branch, "2.1"}}},
+        {riak_auth_mods, ".*", {git, "git://github.com/basho/riak_auth_mods.git", {branch, "2.1"}}},
+        {rebar_lock_deps_plugin, ".*", {git, "git://github.com/seth/rebar_lock_deps_plugin.git", "7a5835029c42b8138325405237ea7e8516a84800"}}
        ]}.
 
 {plugins, [rebar_lock_deps_plugin]}.


### PR DESCRIPTION
Update 2.1's rebar.config to match our current versioning focus, remove need for meck at the top-level, matching riak_ee. 
