### PR TITLE
Moved riak_ql to reltool ref

### DIFF
--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -33,7 +33,8 @@
          erlydtl,
          riak_auth_mods,
          {folsom, load},
-         {riak_ensemble, load}
+         {riak_ensemble, load},
+         riak_ql
         ]},
        {rel, "start_clean", "",
         [


### PR DESCRIPTION
This removes the riak_ql dependency from riak_kv, in favor of a modification to load riak_ql via reltool.config.
