### PR TITLE
Support riak-debug on Solaris 10 (2.0 branch)

### DIFF
--- a/rel/files/riak-debug
+++ b/rel/files/riak-debug
@@ -492,7 +492,7 @@ if [ 1 -eq $get_riakcmds ]; then
     riak_epaths=`make_app_epaths "${riak_app_config}"`
 
     # Get one http listener (epath might output a newline-separated list).
-    riak_api_http="`epath 'riak_api http' "$riak_epaths" | sed -e 's/^"//' -e 's/" /:/' | head -n1`"
+    riak_api_http="`epath 'riak_api http' "$riak_epaths" | sed -e 's/^\"//' -e 's/\" /:/' | head -n1`"
 
     # Dump the output of the /stats HTTP endpoint.
     dump riak_http_stats curl -s "http://$riak_api_http/stats"
@@ -501,7 +501,7 @@ if [ 1 -eq $get_riakcmds ]; then
     mkdir_or_die "${start_dir}"/"${debug_dir}"/ring/.info
     cd "${start_dir}"/"${debug_dir}"/ring
 
-    ring_dir="`epath 'riak_core ring_state_dir' "$riak_epaths" | sed -e 's/^"//' -e 's/".*$//'`"
+    ring_dir="`epath 'riak_core ring_state_dir' "$riak_epaths" | sed -e 's/^\"//' -e 's/\".*$//'`"
     if [ '/' != `echo "$ring_dir" | cut -c1` ]; then
         # relative path. prepend base dir
         ring_dir="$riak_base_dir"/"$ring_dir"
@@ -534,13 +534,13 @@ if [ 1 -eq $get_yzcmds ]; then
     # if not already made, make a flat, searchable version of the app.config
     [ -z "$riak_epaths" ] && riak_epaths=`make_app_epaths "${riak_app_config}"`
 
-    yz_dir="`epath 'yokozuna root_dir' "$riak_epaths" | sed -e 's/^"//' -e 's/".*$//'`"
+    yz_dir="`epath 'yokozuna root_dir' "$riak_epaths" | sed -e 's/^\"//' -e 's/\".*$//'`"
     if [ '/' != `echo "$yz_dir" | cut -c1` ]; then
         # relative path. prepend base dir
         yz_dir="$riak_base_dir"/"$yz_dir"
     fi
 
-    yz_aae_dir="`epath 'yokozuna anti_entropy_data_dir' "$riak_epaths" | sed -e 's/^"//' -e 's/".*$//'`"
+    yz_aae_dir="`epath 'yokozuna anti_entropy_data_dir' "$riak_epaths" | sed -e 's/^\"//' -e 's/\".*$//'`"
     if [ '/' != `echo "$yz_aae_dir" | cut -c1` ]; then
         # relative path. prepend base dir
         yz_aae_dir="$riak_base_dir"/"$yz_aae_dir"
@@ -608,7 +608,7 @@ if [ 1 -eq $get_logs ]; then
     # if not already made, make a flat, searchable version of the app.config
     [ -z "$riak_epaths" ] && riak_epaths=`make_app_epaths "${riak_app_config}"`
 
-    log_dir="`epath 'riak_core platform_log_dir' "$riak_epaths" | sed -e 's/^"//' -e 's/".*$//'`"
+    log_dir="`epath 'riak_core platform_log_dir' "$riak_epaths" | sed -e 's/^\"//' -e 's/\".*$//'`"
     if [ '/' != `echo "$log_dir" | cut -c1` ]; then
         # relative path. prepend base dir
         log_dir="$riak_base_dir"/"$log_dir"
@@ -634,9 +634,9 @@ if [ 1 -eq $get_logs ]; then
     fi
 
     # Lager info and error files
-    new_format_lager_files="`epath 'lager handlers lager_file_backend file' "$riak_epaths" | sed -e 's/^"//' -e 's/".*$//'`"
+    new_format_lager_files="`epath 'lager handlers lager_file_backend file' "$riak_epaths" | sed -e 's/^\"//' -e 's/\".*$//'`"
     if [ -z "$new_format_lager_files" ]; then
-        lager_files="`epath 'lager handlers lager_file_backend' "$riak_epaths" | cut -d' ' -f 1 | sed -e 's/^"//' -e 's/".*$//'`"
+        lager_files="`epath 'lager handlers lager_file_backend' "$riak_epaths" | cut -d' ' -f 1 | sed -e 's/^\"//' -e 's/\".*$//'`"
     else
         lager_files=$new_format_lager_files
     fi
@@ -663,7 +663,7 @@ if [ 1 -eq $get_logs ]; then
     # Gather backend logs, listing, sizing information, etc..
     backend=`epath 'riak_kv storage_backend' "$riak_epaths"`
     if [ 'riak_kv_eleveldb_backend' = "$backend" ]; then
-        leveldb_dir="`epath 'eleveldb data_root' "$riak_epaths" | sed -e 's/^"//' -e 's/".*$//'`"
+        leveldb_dir="`epath 'eleveldb data_root' "$riak_epaths" | sed -e 's/^\"//' -e 's/\".*$//'`"
 
         if [ '/' != `echo "$leveldb_dir" | cut -c1` ]; then
             # relative path. prepend base dir
@@ -694,7 +694,7 @@ if [ 1 -eq $get_logs ]; then
             ' "${start_dir}"/"${debug_dir}"/logs/leveldb {} \;
 
     elif [ 'riak_kv_bitcask_backend' = "$backend" ]; then
-        bitcask_dir="`epath 'bitcask data_root' "$riak_epaths" | sed -e 's/^"//' -e 's/".*$//'`"
+        bitcask_dir="`epath 'bitcask data_root' "$riak_epaths" | sed -e 's/^\"//' -e 's/\".*$//'`"
 
         if [ '/' != `echo "$bitcask_dir" | cut -c1` ]; then
             # relative path. prepend base dir
@@ -724,7 +724,7 @@ if [ 1 -eq $get_logs ]; then
             backend="`epath "riak_kv multi_backend $b" "$riak_epaths" | cut -d ' ' -f 1 | uniq`"
             if [ 'riak_kv_eleveldb_backend' = "$backend" ]; then
                 dr="`epath "riak_kv multi_backend $b riak_kv_eleveldb_backend data_root" "$riak_epaths" |
-                    sed -e 's/^"//' -e 's/".*$//'`"
+                    sed -e 's/^\"//' -e 's/\".*$//'`"
 
                 if [ '/' != `echo "$dr" | cut -c1` ]; then
                     # relative path. prepend base dir
@@ -756,7 +756,7 @@ if [ 1 -eq $get_logs ]; then
 
             elif [ 'riak_kv_bitcask_backend' = "$backend" ]; then
                 dr="`epath "riak_kv multi_backend $b riak_kv_bitcask_backend data_root" "$riak_epaths" |
-                    sed -e 's/^"//' -e 's/".*$//'`"
+                    sed -e 's/^\"//' -e 's/\".*$//'`"
 
                 if [ '/' != `echo "$dr" | cut -c1` ]; then
                     # relative path. prepend base dir
@@ -787,7 +787,7 @@ if [ 1 -eq $get_logs ]; then
     # an empty variable regardless of the value set in the configuration
     # settings. We're going to grab the `anti_entropy_data_dir` instead, and
     # assume it's presence on disk indicates activity.
-    anti_entropy_dir="`epath 'riak_kv anti_entropy_data_dir' "$riak_epaths" | sed -e 's/^"//' -e 's/".*$//'`"
+    anti_entropy_dir="`epath 'riak_kv anti_entropy_data_dir' "$riak_epaths" | sed -e 's/^\"//' -e 's/\".*$//'`"
 
     if [ '/' != `echo "$anti_entropy_dir" | cut -c1` ]; then
         # relative path. prepend base dir

--- a/rel/files/riak-debug
+++ b/rel/files/riak-debug
@@ -899,9 +899,9 @@ fi
 
 if [ '-' = "$outfile" ]; then
     # So we don't get a file literally named -
-    tar zcf - "${debug_dir}"
+    tar cf - "${debug_dir}" | gzip
 else
-    tar zcf "$outfile" "${debug_dir}"
+    tar cf - "${debug_dir}" | gzip > "$outfile"
 
     # provide some indication of the output filename
     printf " $outfile" 1>&2

--- a/rel/files/riak-debug
+++ b/rel/files/riak-debug
@@ -30,7 +30,8 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
     POSIX_SHELL="true"
     export POSIX_SHELL
     # To support 'whoami' add /usr/ucb to path
-    PATH=/usr/ucb:$PATH
+    # To use 'nawk' as 'awk', add /usr/xpg4/bin to path
+    PATH=/usr/xpg4/bin:/usr/ucb:$PATH
     export PATH
     exec /usr/bin/ksh $0 "$@"
 fi


### PR DESCRIPTION
A fix for #796 (RIAK-2308) (RIAK-2314).
- The default Solaris 10 version of awk doesn't support gsub, use xpg4 awk (nawk) instead.
- Tar on Solaris 10 has no support for creating compressed tar.gz files. Pipe tar file into gzip instead.
- Non-bash (e.g. ksh) shells may not have support for single instances of double quotes nested in single quotes. Escape nested double quotes.
