### PR TITLE
don't leave bin/riak-shell behind when making rel

### DIFF
--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -123,6 +123,7 @@
            {template, "files/riak-admin", "bin/riak-admin"},
            {template, "files/riak-debug", "bin/riak-debug"},
            {template, "files/search-cmd", "bin/search-cmd"},
+           {template, "../deps/riak_shell/bin/riak-shell", "bin/riak-shell"},
 
            {mkdir, "lib/basho-patches"},
            {copy, "../apps/riak/ebin/etop_txt.beam", "lib/basho-patches"},


### PR DESCRIPTION
Add a new entry in reltool.config to fetch deps/riak_shell/bin/riak-shell escript for release and packaging.
