### PR TITLE
Bump Riak 2.0 cuttlefish version to 2.0.2p1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,7 +15,7 @@
 
 {deps, [
         {node_package, ".*", {git, "git://github.com/basho/node_package.git", {branch, "develop"}}},
-        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {tag, "2.0.2"}}},
+        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {tag, "2.0.2p1"}}},
         {lager_syslog, "2.0.3", {git, "git://github.com/basho/lager_syslog.git", {tag, "2.0.3"}}},
         {cluster_info, ".*", {git, "git://github.com/basho/cluster_info.git", {branch, "develop"}}},
         {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {branch, "2.0"}}},


### PR DESCRIPTION
This pulls in a slightly updated version of cuttlefish that includes
Doug's fix for increasing the default ERL_MAX_PORTS setting.
