### PR TITLE
deps target enhancement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 REPO            ?= riak
-PKG_REVISION    ?= $(shell git describe --tags)
+HEAD_REVISION   ?= $(shell git describe --tags --exact-match HEAD 2>/dev/null)
+PKG_REVISION    ?= $(shell git describe --tags 2>/dev/null)
 PKG_BUILD        = 1
 BASE_DIR         = $(shell pwd)
-ERLANG_BIN       = $(shell dirname $(shell which erl))
+ERLANG_BIN       = $(shell dirname $(shell which erl 2>/dev/null) 2>/dev/null)
 REBAR           ?= $(BASE_DIR)/rebar
 OVERLAY_VARS    ?=
 
@@ -22,6 +23,7 @@ compile:
 	./rebar compile
 
 deps:
+	$(if $(HEAD_REVISION),$(warning "Warning: you have checked out a tag ($(HEAD_REVISION)) and should use the locked-deps target"))
 	./rebar get-deps
 
 clean: testclean


### PR DESCRIPTION
Warn user that, if on checked out tag, `locked-deps` should be used.
