### PR TITLE
Remove cluster-info command from riak-debug [JIRA: RIAK-2879]

### DIFF
--- a/rel/files/riak-debug
+++ b/rel/files/riak-debug
@@ -482,12 +482,6 @@ if [ 1 -eq $get_riakcmds ]; then
     dump riak_diag "$riak_bin_dir"/riak-admin diag
     dump riak_repl_status "$riak_bin_dir"/riak-repl status
 
-    CI=`pwd`/cluster-info.html
-    touch $CI
-    chmod 666 $CI
-    dump cluster-info riak-admin cluster-info $CI local
-    chmod 444 $CI
-
     # Make a flat, easily searchable version of the app.config settings
     riak_epaths=`make_app_epaths "${riak_app_config}"`
 


### PR DESCRIPTION
https://github.com/basho/riak/issues/832 explains that a riak-debug that also executes the cluster-info command has been seen to crash an already stressed node. We should run cluster-info separately if this information is required. Everything else in riak-debug is very useful and fairly lightweight to run.
