### PR TITLE
The head of any existing erl_crash.dump now captured in riak-debug

### DIFF
--- a/rel/files/riak-debug
+++ b/rel/files/riak-debug
@@ -630,6 +630,8 @@ if [ 1 -eq $get_logs ]; then
                 mkdir -p "$0/${1%/*}";
                 cp "$1" "$0/$1"
                 ' "${start_dir}"/"${debug_dir}"/logs/platform_log_dir {} \;
+            # Grab the head of any crash dumps
+            if [ -f "erl_crash.dump" ]; then head erl_crash.dump > "${start_dir}"/"${debug_dir}"/logs/platform_log_dir/erl_crash.dump; fi
         fi
     fi
 


### PR DESCRIPTION
Normally, an **erl_crash.dump** is not included in a riak-debug as the file can be extremely large.  This commit means the head (first 10 lines) of the file will be included in the debug rather than ignoring it completely.  This allows us to see the Slogan line at the top.
