### PR TITLE
Use node_package 3.0.1 instead of develop branch

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,7 @@
                ]}.
 
 {deps, [
-        {node_package, ".*", {git, "git://github.com/basho/node_package.git", {branch, "develop"}}},
+        {node_package, ".*", {git, "git://github.com/basho/node_package.git", {tag, "3.0.1"}}},
         {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {tag, "2.0.2p2"}}},
         {lager_syslog, "2.0.3", {git, "git://github.com/basho/lager_syslog.git", {tag, "2.0.3"}}},
         {cluster_info, ".*", {git, "git://github.com/basho/cluster_info.git", {branch, "develop"}}},


### PR DESCRIPTION
In EE 2.0 we use the 3.0.1 tag, but for some reason in OSS 2.0 we're using the develop branch. This happens to be the same right now, but may change in the future, and we should use a tag like EE to keep things consistent. (For reference, the develop-2.2 branch is also using the 3.0.1 tag for both OSS and EE, so OSS 2.0 definitely seems like the odd one out.)
