### PR TITLE
RIAK-2583 Async Job Switches

### DIFF
--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -118,6 +118,7 @@
            {template, "../deps/riak_kv/priv/multi_backend.schema", "lib/20-multi_backend.schema"},
            {template, "../deps/eleveldb/priv/eleveldb.schema", "lib/21-leveldb.schema"},
            {template, "../deps/eleveldb/priv/eleveldb_multi.schema", "lib/22-leveldb_multi.schema"},
+           {template, "../deps/riak_search/priv/riak_search.schema", "lib/29-riak_search.schema"},
            {template, "../deps/yokozuna/priv/yokozuna.schema", "lib/30-yokozuna.schema"},
 
            %% Copy additional bin scripts


### PR DESCRIPTION
Adds switches for the following operations arriving through HTTP or protobuf interfaces:
- `{riak_kv, list_buckets}`
- `{riak_kv, list_keys}`
- `{riak_kv, map_reduce_js}` _(see KV PR caveats)_
- `{riak_kv, map_reduce}`
- `{riak_kv, secondary_index}`
- `{riak_kv, stream_list_buckets}`
- `{riak_kv, stream_list_keys}`
- `{riak_kv, stream_secondary_index}`
- `{riak_search, query}`
- `{yokozuna, query}`

Prerequisites:
- [x] [riak_core PR #851 (RIAK-2668)](https://github.com/basho/riak_core/pull/851)
- [x] [riak_kv PR #1459](https://github.com/basho/riak_kv/pull/1459)
- [x] [riak_search PR #184 (RIAK-1872) (RIAK-1920) (RIAK-1944) (RIAK-2349)](https://github.com/basho/riak_search/pull/184)
- [x] [yokozuna PR #671 (RIAK-2187)](https://github.com/basho/yokozuna/pull/671)
