### PR TITLE
Enable Travis CI build

### DIFF
--- a/.travis-test.sh
+++ b/.travis-test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+
+declare -r travis_build_dir="$1"
+declare -r riak_dev_dir="$travis_build_dir/dev"
+
+if [[ ! -d $riak_dev_dir ]]
+then
+    echo "Expected to find $riak_dev_dir directory, exiting!" 1>&2
+    exit 1
+fi
+
+declare -r riak_erlang_client_dir="$HOME/build/riak-erlang-client"
+
+git clone --depth=50 https://github.com/basho/riak-erlang-client.git "$riak_erlang_client_dir"
+
+cd "$riak_erlang_client_dir"
+
+git submodule update --init
+
+./tools/devrel/setup-dev-cluster -p "$riak_dev_dir"
+
+if ! hash escript
+then
+    set +o nounset
+    set +o errexit
+    source "$HOME/otp-basho/activate"
+    set -o nounset
+    set -o errexit
+fi
+
+export RIAK_TEST_HOST_1=127.0.0.1
+export RIAK_TEST_NODE_1=dev1@127.0.0.1
+export RIAK_TEST_PBC_1=10017
+make
+make test

--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+
+declare -r build_status="$(mktemp)"
+declare -r otp_name='OTP_R16B02_basho10'
+declare -r otp_build_log_dir="$HOME/.kerl/builds/$otp_name"
+declare -r otp_install_dir="$HOME/otp-basho"
+
+function onexit
+{
+    rm -vf "$build_status"
+}
+
+trap onexit EXIT
+
+function build_ticker
+{
+    local status="$(< $build_status)"
+    while [[ $status == 'true' ]]
+    do
+        echo '------------------------------------------------------------------------------------------------------------------------------------------------'
+        echo "$(date) building $otp_name ..."
+        if ls $otp_build_log_dir/otp_build*.log > /dev/null
+        then
+            tail $otp_build_log_dir/otp_build*.log
+        fi
+        sleep 10
+        status="$(< $build_status)"
+    done
+    echo '.'
+}
+
+if [[ -f $otp_install_dir/activate ]]
+then
+    echo "Found OTP installation at $otp_install_dir"
+else
+    export KERL_CONFIGURE_OPTIONS='--enable-hipe --enable-smp-support --enable-threads --enable-kernel-poll --without-odbc'
+    rm -rf "$otp_install_dir"
+    mkdir -p "$otp_install_dir"
+
+    echo -n 'true' > "$build_status"
+    build_ticker &
+    kerl build git https://github.com/basho/otp.git "$otp_name" "$otp_name"
+    echo -n 'false' > "$build_status"
+    wait
+
+    kerl install "$otp_name" "$otp_install_dir"
+fi
+
+exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: erlang
+otp_release:
+- R16B03
+cache:
+  directories:
+  - "$HOME/otp-basho"
+addons:
+  apt:
+    packages:
+    - libpam0g-dev
+before_script:
+- ./.travis.sh
+script:
+  - source "$HOME/otp-basho/activate"
+  - make stagedevrel DEVNODES=3
+  - ./.travis-test.sh "$TRAVIS_BUILD_DIR"
+notifications:
+  slack:
+    secure: CsnR4hd427mH+ST5u5FItN8qUEl+1N7yTSfH3pVr1oKsmsr15uvU7xB65ui+hQqlPVKXlWumA+ZLZ0P9Q95+iFd4qAv7hy6xkimvMC72+FY9fOpNppc9sMB1mq+UCEXgA0yNtJSoimFxW7OyI6I04OC8MBa/BvJQytRMHnqwkq8=


### PR DESCRIPTION
Features:
- Builds OTP using [Basho's patched version](https://github.com/basho/otp/tree/OTP_R16B02_basho10)
- Travis is configured to cache and re-use custom OTP
- Riak cluster is started and full `riak-erlang-client` integration test suite run
- Enables notifications

Builds available here: https://travis-ci.org/lukebakken/riak
