### PR TITLE
Cleaned up rebar dependencies

### DIFF
--- a/.thumbs.yml
+++ b/.thumbs.yml
@@ -1,0 +1,8 @@
+minimum_reviewers: 1
+build_steps:
+ - make deps
+ - make
+ - make rel
+merge: false
+org_mode: true
+timeout: 1790

--- a/rebar.config
+++ b/rebar.config
@@ -13,16 +13,17 @@
                 {compiler_options, [report, return, debug_info]}
                ]}.
 {deps, [
-        {rebar_lock_deps_plugin, ".*", {git, "https://github.com/basho/rebar_lock_deps_plugin.git", {branch, "master"}}},
-        {node_package, ".*", {git, "https://github.com/basho/node_package.git", {tag, "4.0.1"}}},
-        {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog.git", {tag, "2.0.3"}}},
-        {cluster_info, ".*", {git, "git://github.com/basho/cluster_info.git", {branch, "develop"}}},
-        {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {branch, "develop"}}},
-        {riak_search, ".*", {git, "git://github.com/basho/riak_search.git", {branch, "develop"}}},
-        {riak_control, ".*", {git, "git://github.com/basho/riak_control.git", {branch, "develop"}}},
-        {riaknostic, ".*", {git, "git://github.com/basho/riaknostic.git", {branch, "develop"}}},
-        {yokozuna, ".*", {git, "git://github.com/basho/yokozuna.git", {branch, "develop"}}},
-        {riak_auth_mods, ".*", {git, "git://github.com/basho/riak_auth_mods.git", {branch, "develop"}}}
+        {node_package, ".*", {git, "https://github.com/basho/node_package.git", {tag, "3.1.1"}}},
+        {lager_syslog, ".*", {git, "https://github.com/basho/lager_syslog.git", {tag, "3.0.3"}}},
+        {cluster_info, ".*", {git, "https://github.com/basho/cluster_info.git", {tag, "2.0.3"}}},
+        {riak_kv, ".*", {git, "https://github.com/basho/riak_kv.git", {branch, "develop"}}},
+        {riak_search, ".*", {git, "https://github.com/basho/riak_search.git", {branch, "develop"}}},
+        {riak_control, ".*", {git, "https://github.com/basho/riak_control.git", {branch, "develop"}}},
+        {riaknostic, ".*", {git, "https://github.com/basho/riaknostic.git", {tag, "2.1.5"}}},
+        {yokozuna, ".*", {git, "https://github.com/basho/yokozuna.git", {branch, "develop"}}},
+        {riak_auth_mods, ".*", {git, "https://github.com/basho/riak_auth_mods.git", {tag, "2.1.0"}}},
+        {meck, "0.8.2", {git, "https://github.com/basho/meck.git", {tag, "0.8.2"}}},
+        {rebar_lock_deps_plugin, ".*", {git, "https://github.com/basho/rebar_lock_deps_plugin.git", {tag, "3.1.0p1"}}}
        ]}.
 
 {plugins, [rebar_lock_deps_plugin]}.


### PR DESCRIPTION
 The PR cleans up rebar dependencies on the develop branch so that the transitive closure of all dependencies in the repo are consistent, i.e., they don't point to different tags or branches of the same repo.

This PR also makes dependencies on key repositories, such as riak_kv and riak_core, which are under active development, branch dependencies on their respective develop branches.