### PR TITLE
Fix RIAK-2702 by restricting atom usage to 1000

### DIFF
--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -1050,6 +1050,7 @@ case "$1" in
 
         RAND=$(($(($RANDOM % 1000)) + 1))
         NODE_NAME=${NAME_ARG#* }
+        # Using np_etop instead of riak_etop to follow node_package convention
         $ERTS_PATH/erl -noshell -noinput \
             -pa $RUNNER_LIB_DIR/basho-patches \
             -hidden $NAME_PARAM np_etop$RAND$NAME_HOST $COOKIE_ARG \

--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -1048,11 +1048,11 @@ case "$1" in
 
         shift
 
-        MYPID=$$
+        RAND=$(bc <<< "$(($(($RANDOM % 1000)) + 1))")
         NODE_NAME=${NAME_ARG#* }
         $ERTS_PATH/erl -noshell -noinput \
             -pa $RUNNER_LIB_DIR/basho-patches \
-            -hidden $NAME_PARAM riak_etop$MYPID$NAME_HOST $COOKIE_ARG \
+            -hidden $NAME_PARAM riak_etop$RAND$NAME_HOST $COOKIE_ARG \
             -s etop -s erlang halt -output text \
             -node $NODE_NAME \
             $* -tracing off

--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -1048,11 +1048,11 @@ case "$1" in
 
         shift
 
-        RAND=$(bc <<< "$(($(($RANDOM % 1000)) + 1))")
+        RAND=$(($(($RANDOM % 1000)) + 1))
         NODE_NAME=${NAME_ARG#* }
         $ERTS_PATH/erl -noshell -noinput \
             -pa $RUNNER_LIB_DIR/basho-patches \
-            -hidden $NAME_PARAM riak_etop$RAND$NAME_HOST $COOKIE_ARG \
+            -hidden $NAME_PARAM np_etop$RAND$NAME_HOST $COOKIE_ARG \
             -s etop -s erlang halt -output text \
             -node $NODE_NAME \
             $* -tracing off


### PR DESCRIPTION
`riak-admin top` uses `$$` to randomize the name used to connect to the
local Riak node. The large range of possible OS pids can result in atom
table exhaustion on long running nodes/clusters. Use `$RANDOM` and
restrict the range to 1-1000.