### PR TITLE
[RFC] Produce syslog level placeholder in riak.conf

### DIFF
--- a/rel/files/riak.schema
+++ b/rel/files/riak.schema
@@ -55,8 +55,7 @@
 %% @doc The severity level at which to log entries to syslog, default is 'info'.
 {mapping, "log.syslog.level", "lager.handlers", [
   {default, info},
-  {datatype, {enum, [debug, info, notice, warning, error, critical, alert, emergency, none]}},
-  hidden
+  {datatype, {enum, [debug, info, notice, warning, error, critical, alert, emergency, none]}}
 ]}.
 
 {translation,


### PR DESCRIPTION
... analogously to `log.console.level`.

It is already documented at
http://docs.basho.com/riak/kv/2.2.3/configuring/reference/#logging

----

I did not run tests yet - I thought I would better ask first if there were any reasons why this config was hidden in the first place.

BTW on the home page the link in "You can read the full guidelines for bug reporting and code contributions on the Riak Docs." links to http://docs.basho.com/riak/latest/community/bugs/ that redirects to http://docs.basho.com/riak/kv/2.2.3/community/bugs/ that gives 404.