### PR TITLE
Not all builders want to run all deps' tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ ERLANG_BIN       = $(shell dirname $(shell which erl 2>/dev/null) 2>/dev/null)
 REBAR           ?= $(BASE_DIR)/rebar
 OVERLAY_VARS    ?=
 SPECIAL_DEPS	?= meck hamcrest riak_ensemble webmachine
+TEST_IGNORE     ?=
 
 RIAK_CORE_STAT_PREFIX = riak
 export RIAK_CORE_STAT_PREFIX
@@ -60,11 +61,12 @@ testclean:
 # Test each dependency individually in its own VM
 test : deps compile testclean
 	@$(foreach dep, \
-		$(filter-out $(SPECIAL_DEPS), $(patsubst deps/%, %, $(wildcard deps/*))), \
+		$(filter-out $(TEST_IGNORE), \
+			$(filter-out $(SPECIAL_DEPS), $(patsubst deps/%, %, $(wildcard deps/*)))), \
 			(cd deps/$(dep) && REBAR_DEPS_DIR=$(BASE_DIR)/deps/ ../../rebar eunit deps_dir=.. skip_deps=true)  \
 			|| echo "Eunit: $(dep) FAILED" >> $(TEST_LOG_FILE);)
 	@$(foreach special, \
-		$(SPECIAL_DEPS), \
+		$(filter-out $(TEST_IGNORE), $(SPECIAL_DEPS)), \
 			(cd deps/$(special) && make test)  \
 			|| echo "Eunit: $(special) FAILED" >> $(TEST_LOG_FILE);)
 	./rebar eunit skip_deps=true


### PR DESCRIPTION
For example, some organisations do not use, nor have the time to
maintain, some deps, like riak_ensemble. This change adds an argument
`TEST_IGNORE` that will skip the eunit test running for the deps
assigned to the variable.

Example::

    make test TEST_IGNORE="riak_ensemble yokozuna"

Will run eunit, but skip those directories. Compile will still run.