### PR TITLE
Add ulimit check on startup.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -84,7 +84,9 @@
          {template, "rel/files/riak-debug",        "bin/riak-debug"},
          {template, "rel/files/riak-chkconfig",    "bin/riak-chkconfig"},
          {template, "rel/files/riak-repl",         "bin/riak-repl"},
-	 {template, "rel/files/check_riak_config", "bin/check_riak_config"}
+         {template, "rel/files/check_riak_config", "bin/check_riak_config"},
+
+         {copy, "rel/files/check_ulimit", "bin/hooks/prestart/check_ulimit"}
     ]},
 
     {generate_start_script, true},
@@ -97,6 +99,9 @@
     ]},
 
     {extended_start_script_hooks, [
+        {pre_start, [
+            {custom, "hooks/prestart/check_ulimit"}
+        ]},
         {post_start, [
             {wait_for_process, riak_core_node_watcher}
         ]}

--- a/rel/files/check_ulimit
+++ b/rel/files/check_ulimit
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+ULIMIT_WARN=65536
+ULIMIT_F=`ulimit -n`
+
+if [ "$ULIMIT_F" -lt $ULIMIT_WARN ]; then
+    echo "!!!!"
+    echo "!!!! WARNING: ulimit -n is ${ULIMIT_F}; ${ULIMIT_WARN} is the recommended minimum."
+    echo "!!!!"
+fi


### PR DESCRIPTION
Re-enable the checking of file handle limit on startup. Was previously handled in node_package - added as a prestart extension.