### PR TITLE
Add pre-start hook for checking node not running at start

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -86,7 +86,9 @@
          {template, "rel/files/riak-repl",         "bin/riak-repl"},
          {template, "rel/files/check_riak_config", "bin/check_riak_config"},
 
-         {copy, "rel/files/check_ulimit", "bin/hooks/prestart/check_ulimit"}
+         {copy, "rel/files/check_ulimit", "bin/hooks/check_ulimit"},
+         {copy, "rel/files/riak_not_running", "bin/hooks/riak_not_running"}
+
     ]},
 
     {generate_start_script, true},
@@ -98,14 +100,15 @@
         {chkconfig, "riak-chkconfig"}
     ]},
 
-    {extended_start_script_hooks, [
-        {pre_start, [
-            {custom, "hooks/prestart/check_ulimit"}
-        ]},
-        {post_start, [
-            {wait_for_process, riak_core_node_watcher}
-        ]}
-    ]}
+
+    {extended_start_script_hooks,
+     [ {pre_start,
+        [{custom, "hooks/riak_not_running"},
+         {custom, "hooks/check_ulimit"}]},
+      {post_start,
+       [{wait_for_process, riak_core_node_watcher}
+       ]}
+     ]}
 ]}.
 
 {profiles, [

--- a/rel/files/riak_not_running
+++ b/rel/files/riak_not_running
@@ -1,0 +1,8 @@
+#!/bin/sh
+# -*- tab-width:4;indent-tabs-mode:nil -*-
+# ex: ts=4 sw=4 et
+
+if relx_nodetool "ping" > /dev/null; then
+    echo "Node is already running!"
+    exit 1
+fi


### PR DESCRIPTION
Moved ulimit check from hooks/prestart to hooks, because one is free to run this script before status or any other command if one would like to do so. Is actually not bound to start.

It is debatable whether we really need 2 scripts for start check, but this is quite clean approach