### PR TITLE
Fix devrel generation and output-dir / overlay_vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ $(eval devrel : $(foreach n,$(SEQ),dev$(n)))
 
 dev% : all
 	rel/gen_dev $@ rel/vars/dev_vars.config.src rel/vars/$@_vars.config
-	$(REBAR) as dev release -o dev/$@ --overlay_vars rel/vars/$@_vars.config
+	$(REBAR) release -o dev/$@ --overlay_vars rel/vars/$@_vars.config
 
 perfdev : all
 	perfdev/bin/riak stop || :

--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,12 @@ $(eval stagedevrel : $(foreach n,$(SEQ),stagedev$(n)))
 $(eval devrel : $(foreach n,$(SEQ),dev$(n)))
 
 dev% : all
-	rel/gen_dev $@ rel/vars/dev_vars.config.src rel/vars/$@_vars.config
-	$(REBAR) release -o dev/$@ --overlay_vars rel/vars/$@_vars.config
+	rel/gen_dev dev$* rel/vars/dev_vars.config.src rel/vars/$*_vars.config
+	$(REBAR) release -o dev/dev$* --overlay_vars rel/vars/$*_vars.config
+
+stagedev% : all
+	rel/gen_dev dev$* rel/vars/dev_vars.config.src rel/vars/$*_vars.config
+	$(REBAR) as dev release -o dev/dev$* --overlay_vars rel/vars/$*_vars.config
 
 perfdev : all
 	perfdev/bin/riak stop || :
@@ -118,9 +122,6 @@ perf:
 	perfdev/bin/riak-admin wait-for-service riak_kv 'perfdev@127.0.0.1'
 	escript apps/riak/src/riak_perf_smoke || :
 	perfdev/bin/riak stop
-
-stagedev% : dev%
-	  $(foreach dep,$(wildcard deps/*), rm -rf dev/$^/lib/$(shell basename $(dep))* && ln -sf $(abspath $(dep)) dev/$^/lib;)
 
 devclean: clean
 	rm -rf dev

--- a/Makefile
+++ b/Makefile
@@ -100,17 +100,9 @@ SEQ = $(shell awk 'BEGIN { for (i = 1; i < '$(DEVNODES)'; i++) printf("%i ", i);
 $(eval stagedevrel : $(foreach n,$(SEQ),stagedev$(n)))
 $(eval devrel : $(foreach n,$(SEQ),dev$(n)))
 
-## need absolute path for overlay_vars due to rebar3 bug
-## We want to use ./rebar3 release --overlay_vars rel/vars/$@_vars.config
-## but somehow that seems not to work
 dev% : all
-	mkdir -p dev
-	cp rel/vars.config rel/vars.config.backup
 	rel/gen_dev $@ rel/vars/dev_vars.config.src rel/vars/$@_vars.config
-	cp rel/vars/$@_vars.config rel/vars.config
-	$(REBAR) release
-	cp -r _build/default/rel/riak/ dev/$@/
-	mv rel/vars.config.backup rel/vars.config
+	$(REBAR) as dev release -o dev/$@ --overlay_vars rel/vars/$@_vars.config
 
 perfdev : all
 	perfdev/bin/riak stop || :

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ test : test-deps
 ## Release targets
 ##
 rel: locked-deps compile 
-	$(REBAR) release
+	$(REBAR) as rel release
 
 relclean:
 	rm -rf $(REL_DIR)

--- a/rebar.config
+++ b/rebar.config
@@ -114,5 +114,10 @@
         {relx, [
             {overlay_vars, "rel/vars.config"}
         ]}
+    ]},
+    {dev, [
+        {relx, [
+            {dev_mode, true}
+        ]}
     ]}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,7 @@
       ]}.
 
 {project_plugins, [
-    {rebar3_cuttlefish, {git, "https://github.com/martincox/rebar3_cuttlefish", {branch, "disable-cf-relbin-scripts"}}}
+    {rebar3_cuttlefish, {git, "https://github.com/martincox/rebar3_cuttlefish", {branch, "fix/output-dir-awareness"}}}
 ]}.
 
 {cuttlefish, [
@@ -73,7 +73,7 @@
     {include_erts, true},
 
     {overlay, [
-         {mkdir, "lib/basho-patches"},
+         {mkdir, "lib/riak-patches"},
 
          {template, "rel/files/advanced.config", "etc/advanced.config"},
 
@@ -110,7 +110,7 @@
 ]}.
 
 {profiles, [
-    {prod, [
+    {rel, [
         {relx, [
             {overlay_vars, "rel/vars.config"}
         ]}

--- a/rebar.config
+++ b/rebar.config
@@ -114,10 +114,5 @@
         {relx, [
             {overlay_vars, "rel/vars.config"}
         ]}
-    ]},
-    {dev, [
-        {relx, [
-            {dev_mode, true}
-        ]}
     ]}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -72,8 +72,6 @@
     {dev_mode, false},
     {include_erts, true},
 
-    {overlay_vars, "rel/vars.config"},
-
     {overlay, [
          {mkdir, "lib/basho-patches"},
 
@@ -112,6 +110,11 @@
 ]}.
 
 {profiles, [
+    {prod, [
+        {relx, [
+            {overlay_vars, "rel/vars.config"}
+        ]}
+    ]},
     {dev, [
         {relx, [
             {dev_mode, true}


### PR DESCRIPTION
This fixes the manual devrel generation by getting output-dir and overlay_vars working correctly.

output-dir is fixed by making the rebar3_cuttlefish plugin aware of the -o or --output-dir switches - previously it wasn't, so the default conf generation (riak.conf) was placed in the normal output directory underneath the profile directory.

overlay_vars seems to have some kind of bug in rebar3, so I've moved the overlay_vars from the default relx release in rebar.config into profiles - prod and dev.