### PR TITLE
Add default vm args in schema to prevent breaking in main process

### DIFF
--- a/priv/riak.schema
+++ b/priv/riak.schema
@@ -218,6 +218,12 @@
   merge
 ]}.
 
+%% VM emulator ignore break signal (prevent ^C / ^Gq)
+{mapping, "erlang.vm.ignore_break_signal", "vm_args.+Bi", [
+  {default, "true"},
+  merge
+]}.
+
 {{#devrel}}
 %% Because of the 'merge' keyword in the proplist below, the docs and datatype
 %% are pulled from the leveldb schema.


### PR DESCRIPTION
Stops accidental termination of vm with ^Gq and ^C when using attach as opposed to remote_console.