### PR TITLE
script name is passed through from riak-admin to clique

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ $(eval devrel : $(foreach n,$(SEQ),dev$(n)))
 
 dev% : all
 	rel/gen_dev dev$* rel/vars/dev_vars.config.src rel/vars/$*_vars.config
-	$(REBAR) release -o dev/dev$* --overlay_vars rel/vars/$*_vars.config
+	$(REBAR) as dev release -o dev/dev$* --overlay_vars rel/vars/$*_vars.config
 
 stagedev% : all
 	rel/gen_dev dev$* rel/vars/dev_vars.config.src rel/vars/$*_vars.config

--- a/rebar.config
+++ b/rebar.config
@@ -128,8 +128,7 @@
                         [{custom, "hooks/riak_not_running"},
                         {custom, "hooks/check_ulimit"}]},
                     {post_start,
-                        [{pid, "/run/riak/riak.pid"},
-                        {wait_for_process, riak_core_node_watcher}]}
+                        [{wait_for_process, riak_core_node_watcher}]}
                     ]}
         ]}
     ]},

--- a/rebar.config
+++ b/rebar.config
@@ -121,14 +121,21 @@
                 ]}
         ]}
     ]},
-    {dev, [{relx, [{dev_mode, true}]}
+    {dev, [{relx, [
+            {dev_mode, true},
+            {extended_start_script_hooks,
+                    [{pre_start,
+                        [{custom, "hooks/riak_not_running"},
+                        {custom, "hooks/check_ulimit"}]},
+                    {post_start,
+                        [{pid, "/run/riak/riak.pid"},
+                        {wait_for_process, riak_core_node_watcher}]}
+                    ]}
+        ]}
     ]},
     {rpm, [
         {relx, [
             {overlay_vars, "rel/pkg/rpm/vars.config"},
-            {overlay, [
-                
-            ]},
             {overlay, [
                 {template, "rel/files/riak", "usr/bin/riak"},
                 {template, "rel/files/riakpre", "usr/bin/riakpre"},

--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -9,7 +9,7 @@ ORIGINAL_DIR=$(pwd)
 cd $RUNNER_BASE_DIR
 
 # Identify the script name
-SCRIPT=`basename $0`
+SCRIPT="riak-admin"
 
 usage() {
     echo "Usage: $SCRIPT { cluster | join | leave | backup | restore | test | "
@@ -281,15 +281,14 @@ cluster_admin()
             relx_nodetool rpc riak_core_console clear_staged
             ;;
         status)
-            echo "script: $SCRIPT / $@"
-            relx_nodetool rpc riak_core_console command "$SCRIPT-admin" cluster $@
+            relx_nodetool rpc riak_core_console command $SCRIPT cluster $@
             ;;
         partitions|partition)
-            relx_nodetool rpc riak_core_console command "$SCRIPT-admin" cluster $@
+            relx_nodetool rpc riak_core_console command $SCRIPT cluster $@
             ;;
         partition[_-]count)
             shift
-            relx_nodetool rpc riak_core_console command "$SCRIPT-admin" cluster partition-count $@
+            relx_nodetool rpc riak_core_console command $SCRIPT cluster partition-count $@
             ;;
         *)
             echo "\


### PR DESCRIPTION
It is currently set to the base script, which is now `riak`. We changed some calls so that they
worked by suffixing the call with `-admin` to work around it.

There was an issue with running `riak admin handoff *`, which slipped through the
net. Looking at this again, seemed better to change the $SCRIPT var rather than
suffix the call, just in case there's anything else that we haven't caught, it
should account for it.