### PR TITLE
add back check to enforce root/sudo startup.

### DIFF
--- a/rel/files/riak
+++ b/rel/files/riak
@@ -8,6 +8,10 @@ RUNNER_LOG_DIR={{platform_log_dir}}
 RELX_CONFIG_PATH=${RUNNER_GEN_DIR}/sys.config
 VMARGS_PATH=${RUNNER_GEN_DIR}/vm.args
 
+if [[ $EUID -ne 0 ]]; then
+   echo "You need to be root or use sudo to run this command." 
+   exit 1
+fi
 
 # On first running the sys.config and vm.args will not be a link
 # as cfconfig has not yet been run as a pre_start hook.  If there's no
@@ -19,31 +23,18 @@ if [ ! -L $VMARGS_PATH ]; then
     cp $RELEASE_ROOT_DIR/releases/{{release_version}}/vm.args $VMARGS_PATH
 fi
 
-# When running as a service, running as riak not as root, and systemd has created PID folder
-if [[ $EUID -ne 0 ]]; then
-    case "$1" in
-        start|console|foreground)
-            RELX_CONFIG_PATH=${RELX_CONFIG_PATH} VMARGS_PATH=${VMARGS_PATH} RUNNER_LOG_DIR=${RUNNER_LOG_DIR} PIPE_DIR=${PIPE_DIR} ${COMMAND} ${*} -pa {{platform_lib_dir}}/patches
-            ;;
-        *)
-            RELX_CONFIG_PATH=${RELX_CONFIG_PATH} VMARGS_PATH=${VMARGS_PATH} RUNNER_LOG_DIR=${RUNNER_LOG_DIR} PIPE_DIR=${PIPE_DIR} ${COMMAND} ${*}
-            ;;
-    esac
-else
-    # In this case we're running sudo riak - so have root access, but cannot rely
-    # systemd having created the PID dir, and need to sudo to the riak user
-    if [ ! -d $PID_DIR ]; then
-        mkdir $PID_DIR
-        chown riak:riak $PID_DIR
-    fi
-    case "$1" in
-        start|console|foreground)
-            su - riak -c "RELX_CONFIG_PATH=${RELX_CONFIG_PATH} VMARGS_PATH=${VMARGS_PATH} RUNNER_LOG_DIR=${RUNNER_LOG_DIR} PIPE_DIR=${PIPE_DIR} ${COMMAND} ${*} -pa {{platform_lib_dir}}/patches"
-            ;;
-        *)
-            su - riak -c "RELX_CONFIG_PATH=${RELX_CONFIG_PATH} VMARGS_PATH=${VMARGS_PATH} RUNNER_LOG_DIR=${RUNNER_LOG_DIR} PIPE_DIR=${PIPE_DIR} ${COMMAND} ${*}"
-            ;;
-    esac
+# In this case we're running sudo riak - so have root access, but cannot rely
+# systemd having created the PID dir, and need to sudo to the riak user
+if [ ! -d $PID_DIR ]; then
+    mkdir $PID_DIR
+    chown riak:riak $PID_DIR
 fi
-
+case "$1" in
+    start|console|foreground)
+        su - riak -c "RELX_CONFIG_PATH=${RELX_CONFIG_PATH} VMARGS_PATH=${VMARGS_PATH} RUNNER_LOG_DIR=${RUNNER_LOG_DIR} PIPE_DIR=${PIPE_DIR} ${COMMAND} ${*} -pa {{platform_lib_dir}}/patches"
+        ;;
+    *)
+        su - riak -c "RELX_CONFIG_PATH=${RELX_CONFIG_PATH} VMARGS_PATH=${VMARGS_PATH} RUNNER_LOG_DIR=${RUNNER_LOG_DIR} PIPE_DIR=${PIPE_DIR} ${COMMAND} ${*}"
+        ;;
+esac
 


### PR DESCRIPTION
I couldn't work out what the first check was being done for. Where we were checking for non-root startup and not su'ing to riak.

I don't think that has any impact? I've run both ways (service & sudo) startup, and there's no difference. Unless there's something obvious I'm missing?