### PR TITLE
Wrong run path for pid

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -142,7 +142,7 @@
                         [{custom, "hooks/riak_not_running"},
                         {custom, "hooks/check_ulimit"}]},
                     {post_start,
-                        [{pid, "/run/riak/riak.pid"},
+                        [{pid, "/var/run/riak/riak.pid"},
                         {wait_for_process, riak_core_node_watcher}]}
                     ]}
         ]}

--- a/rel/pkg/rpm/vars.config
+++ b/rel/pkg/rpm/vars.config
@@ -18,7 +18,7 @@
 {runner_lib_dir,     "/usr/lib64/riak/lib"}.
 {runner_patch_dir,   "/usr/lib64/riak/lib/patches"}.
 {pipe_dir,           "/tmp/riak/"}.
-{pid_dir,            "/run/riak/"}.
+{pid_dir,            "/var/run/riak"}.
 {package_replacement_line, ""}.
 {package_conflicts_line, ""}.
 


### PR DESCRIPTION
worked on centos 7, but not rhel 6. /var/run is symlinked -> /run/. /var/run is across all rhel based distros.