### PR TITLE
Riak-Debug fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ PKG_REVISION    ?= $(shell git describe --tags 2>/dev/null)
 PKG_BUILD        = 1
 BASE_DIR         = $(shell pwd)
 ERLANG_BIN       = $(shell dirname $(shell which erl 2>/dev/null) 2>/dev/null)
-OTP_VER          = $(shell echo $(ERLANG_BIN) | rev | cut -d "/" -f 2 | rev)
 REBAR           ?= $(BASE_DIR)/rebar3
 OVERLAY_VARS    ?=
 TEST_IGNORE     ?= lager riak basho_bench
@@ -211,7 +210,7 @@ REVISION = $(shell echo $(REPO_TAG) | sed -e 's/^$(REPO)-//')
 
 # Primary version identifier, strip off commmit information
 # Changes to 1.0.3 or 1.1.0pre1 from example above
-MAJOR_VERSION	?= $(shell echo $(REVISION) | sed -e 's/\([0-9.]*\)-.*/\1/'|+="-OTP$(OTP_VER)")
+MAJOR_VERSION	?= $(shell echo $(REVISION) | sed -e 's/\([0-9.]*\)-.*/\1/')
 
 # Name resulting directory & tar file based on current status of the git tag
 # If it is a tagged release (PKG_VERSION == MAJOR_VERSION), use the toplevel

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PKG_REVISION    ?= $(shell git describe --tags 2>/dev/null)
 PKG_BUILD        = 1
 BASE_DIR         = $(shell pwd)
 ERLANG_BIN       = $(shell dirname $(shell which erl 2>/dev/null) 2>/dev/null)
+OTP_VER          = $(shell echo $(ERLANG_BIN) | rev | cut -d "/" -f 2 | rev)
 REBAR           ?= $(BASE_DIR)/rebar3
 OVERLAY_VARS    ?=
 TEST_IGNORE     ?= lager riak basho_bench
@@ -210,7 +211,7 @@ REVISION = $(shell echo $(REPO_TAG) | sed -e 's/^$(REPO)-//')
 
 # Primary version identifier, strip off commmit information
 # Changes to 1.0.3 or 1.1.0pre1 from example above
-MAJOR_VERSION	?= $(shell echo $(REVISION) | sed -e 's/\([0-9.]*\)-.*/\1/')
+MAJOR_VERSION	?= $(shell echo $(REVISION) | sed -e 's/\([0-9.]*\)-.*/\1/'|+="-OTP$(OTP_VER)")
 
 # Name resulting directory & tar file based on current status of the git tag
 # If it is a tagged release (PKG_VERSION == MAJOR_VERSION), use the toplevel

--- a/rebar.config
+++ b/rebar.config
@@ -87,9 +87,9 @@
          {template, "rel/files/riak-debug",        "bin/riak-debug"},
          {template, "rel/files/riak-chkconfig",    "bin/riak-chkconfig"},
          {template, "rel/files/riak-repl",         "bin/riak-repl"},
+	 {copy, "rel/files/app_epath.sh",      "lib/app_epath.sh"},
 
          {template, "rel/files/riak",               "usr/bin/riak"},
-
          {copy, "rel/files/check_ulimit", "bin/hooks/check_ulimit"},
          {copy, "rel/files/erl_maxlogsize", "bin/hooks/erl_maxlogsize"},
          {copy, "rel/files/riak_not_running", "bin/hooks/riak_not_running"}

--- a/rel/files/app_epath.sh
+++ b/rel/files/app_epath.sh
@@ -1,0 +1,173 @@
+#!/bin/sh
+
+## ---------------------------------------------------------------------
+##
+## app_epath.sh: Parse Erlang app.config with POSIX tools for automation
+##
+## Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+##
+## This file is provided to you under the Apache License,
+## Version 2.0 (the "License"); you may not use this file
+## except in compliance with the License.  You may obtain
+## a copy of the License at
+##
+##   http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License.
+##
+## ---------------------------------------------------------------------
+
+## Example usage:
+#
+# #!/bin/sh
+#
+# # Load the functions
+# . path/to/app_epath.sh
+# 
+# # Build the path info
+# epaths=`make_app_epaths path/to/app.config`
+#
+# # View all of the settings. Quotes are important.
+# echo "$epaths"
+#
+# # Grep around in the paths for various items.
+# echo "$epaths" | grep 'riak_core ring_creation_size'
+# echo "$epaths" | grep "lager handlers lager_file_backend" | grep info
+#
+# # Use the epath function to get directly at settings
+# epath 'riak_core ring_creation_size' "$epaths"
+# epath 'riak_core platform_bin_dir' "$epaths"
+# epath 'riak_kv storage_backend' "$epaths"
+#
+# # Use epath to view all of the riak_core settings
+# epath riak_core
+#
+## End example
+
+## Here is a command you can put in your path for general cli use.
+# 
+# #!/bin/sh
+# 
+# # $1 quoted eterm path for search: 'riak_core ring_creation_size'
+# # $2 path/to/app.config
+# 
+# . path/to/app_epath.sh
+# 
+# epaths=`make_app_epaths "$2"`
+# epath "$1" "$epaths"
+#
+## End epath command
+
+# make_app_epaths takes a path to an app.config file as its argument and
+# and returns (prints) a flattened text structure of configuration settings.
+
+make_app_epaths () {
+    # Remove all lines containing comments
+    # Remove all blank lines
+    # Remove the first [
+    # Remove the last ].
+    # Remove all blank lines again (just in case)
+    appconfig=`cat $1 \
+                   | sed '/^[ \t]*%/d' \
+                   | sed '/^[ \t]*$/d' \
+                   | sed -e '/\[/{s///;:a' -e '$!N;$!ba' -e '}' \
+                   | sed '$ s/\]\.//g' \
+                   | sed '/^[ \t]*$/d'`
+
+    STACK=
+    INQUOTE=0
+    # The awk puts each char, spaces included, on their own line for parsing.
+    echo "$appconfig" | awk '{gsub(//,"\n");print}' | while read i; do
+        case "x${i}x" in
+            "x\"x")
+                # Flip the INQUOTE state and echo the quote
+                if [ 1 -eq $INQUOTE ]; then
+                    INQUOTE=0
+                else
+                    INQUOTE=1
+                fi
+                STACK="${STACK}${i}"
+                ;;
+            "xx")
+                if [ 1 -eq $INQUOTE ]; then
+                    # If in quotes, keep this space
+                    STACK="${STACK} "
+                fi
+                ;;
+            "x,x")
+                if [ 1 -eq $INQUOTE ]; then
+                    # If in quotes, keep this comma
+                    STACK="${STACK},"
+                else
+                    # Commas outside quotes means a new item is next
+                    STACK="${STACK} "
+                fi
+                ;;
+            "x{x")
+                if [ 1 -eq $INQUOTE ]; then
+                    # If in quotes, keep this bracket
+                    STACK="${STACK}{"
+                else
+                    # Add brace to the stack; will pop off from here on next }
+                    STACK="${STACK} __EBRACE__ "
+                fi
+                ;;
+            "x}x")
+                if [ 1 -eq $INQUOTE ]; then
+                    # If in quotes, keep this bracket
+                    STACK="${STACK}}"
+                else
+                    # We're only interested in printing leaves, not
+                    # intermediates like 'riak_core http', which contain lists.
+                    # See if the current stack ends with ] (end of list).
+                    echo $STACK | grep -E "__EBRACKET__$" >/dev/null 2>&1
+                    if [ 1 -eq $? ]; then
+                        # If not, print the stack without all of the mess.
+                        echo "$STACK" | \
+                            sed 's/ *__EBRACE__//g;s/ *__EBRACKET__//g;s/^ *//'
+                    fi
+                    # Pop off everything from the last brace on.
+                    STACK=`echo "$STACK" | sed 's/\(.*\) __EBRACE__.*/\1/g'`
+                fi
+                ;;
+            "x[x")
+                if [ 1 -eq $INQUOTE ]; then
+                    # If in quotes, keep this bracket
+                    STACK="${STACK}["
+                else
+                    # Add a placeholder to aid in determining whether or not to
+                    # print. That is, we don't want to print 'riak_core http'.
+                    STACK="${STACK} __EBRACKET__ "
+                fi
+                ;;
+            "x]x")
+                if [ 1 -eq $INQUOTE ]; then
+                    # If in quotes, keep this bracket
+                    STACK="${STACK}]"
+                fi
+                # Don't actually do anything with ], as the starting brackets
+                # are instead removed with }.
+                ;;
+            *)
+                # Anything else is just pushed.
+                STACK="${STACK}${i}"
+                ;;
+        esac
+    done
+}
+
+epath () {
+    # arg1   - a pattern to search for
+    # arg2   - output of make_app_epaths, passed in quoted
+    # output - search of arg2 for arg1, trimming arg1 from the beginning
+    #          Note: there may be multiple lines of output.
+    pat=$1
+    shift
+    echo "$*" | grep "$pat " | sed "s/^${pat} *//"
+}
+

--- a/rel/files/riak-debug
+++ b/rel/files/riak-debug
@@ -23,7 +23,7 @@
 ## -------------------------------------------------------------------
 
 # If you start to think "We should execute some Erlang in here", then go work
-# on Riaknostic, which is called with `riak-admin diag` below.
+# on Riaknostic, which is called with `riak admin diag` below.
 
 # /bin/sh on Solaris is not a POSIX compatible shell, but /usr/bin/ksh is.
 if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
@@ -140,6 +140,7 @@ RUNNER_BASE_DIR={{runner_base_dir}}
 riak_base_dir={{runner_base_dir}}
 riak_bin_dir={{runner_script_dir}}
 riak_etc_dir={{runner_etc_dir}}
+riak_sbin_dir=/usr/sbin
 
 get_cfgs=0
 get_ssl_certs=0
@@ -153,7 +154,7 @@ verbose_output=0
 
 ## Use riak config generate to set $riak_app_config and
 ## $riak_vm_args
-gen_result=`"$riak_bin_dir"/riak config generate | cut -d' ' -f 3,5`
+gen_result=`"$riak_bin_dir"/riak chkconfig | grep -v "OK" | cut -d' ' -f 2,4`
 riak_app_config=`echo $gen_result | cut -d' ' -f 1`
 generated_config_dir=`dirname "$riak_app_config"`
 riak_vm_args=`echo $gen_result | cut -d' ' -f 2`
@@ -467,26 +468,32 @@ if [ 1 -eq $get_riakcmds ]; then
     mkdir_or_die "${start_dir}"/"${debug_dir}"/commands/.info
     cd "${start_dir}"/"${debug_dir}"/commands
 
-    # Note that 'riak-admin status' and 'riak-admin transfers' are heavy
+    # Note that 'riak admin status' and 'riak admin transfers' are heavy
     # commands on Riak<=1.2.0 and should not be executed in a loop against all
     # nodes in a cluster.
 
-    dump riak_ping "$riak_bin_dir"/riak ping
-    dump riak_version "$riak_bin_dir"/riak version
-    dump riak_member_status "$riak_bin_dir"/riak-admin member-status
-    dump riak_ring_status "$riak_bin_dir"/riak-admin ring-status
-    dump riak_status "$riak_bin_dir"/riak-admin status
-    dump riak_transfers "$riak_bin_dir"/riak-admin transfers
-    dump riak_aae_status "$riak_bin_dir"/riak-admin aae-status
-    dump riak_search_aae_status "$riak_bin_dir"/riak-admin search aae-status
-    dump riak_diag "$riak_bin_dir"/riak-admin diag
-    dump riak_repl_status "$riak_bin_dir"/riak-repl status
-    dump riak_repl_connections "$riak_bin_dir"/riak-repl connections
-    dump riak_repl_clusterstats "$riak_bin_dir"/riak-repl clusterstats
-    dump riak_repl_modes "$riak_bin_dir"/riak-repl modes
+    dump riak_ping "$riak_sbin_dir"/riak ping
+    dump riak_version "$riak_sbin_dir"/riak version
+    dump riak_member_status "$riak_sbin_dir"/riak admin member-status
+    dump riak_ring_status "$riak_sbin_dir"/riak admin ring-status
+    dump riak_status "$riak_sbin_dir"/riak admin status
+    dump riak_transfers "$riak_sbin_dir"/riak admin transfers
+    dump riak_search_aae_status "$riak_sbin_dir"/riak admin search aae-status
+    dump riak_diag "$riak_sbin_dir"/riak admin diag
+    dump riak_repl_status "$riak_sbin_dir"/riak repl status
+    dump riak_repl_connections "$riak_sbin_dir"/riak repl connections
+    dump riak_repl_clusterstats "$riak_sbin_dir"/riak repl clusterstats
+    dump riak_repl_modes "$riak_sbin_dir"/riak repl modes
 
     # Make a flat, easily searchable version of the app.config settings
     riak_epaths=`make_app_epaths "${riak_app_config}"`
+
+    # If Yokozuna is not installed, $yz_test will be null.
+    yz_test="`epath 'yokozuna root_dir' "$riak_epaths" | sed -e 's/^\"//' -e 's/\".*$//'`"
+    # Only execute the search aae_statis command if $yz_test is not null.
+    if [ -n "$yz_test" ]; then
+        dump riak_search_aae_status "$riak_sbin_dir"/riak admin search aae-status
+    fi
 
     # Get one http listener (epath might output a newline-separated list).
     riak_api_http="`epath 'riak_api http' "$riak_epaths" | sed -e 's/^\"//' -e 's/\" /:/' | head -n1`"
@@ -532,55 +539,59 @@ if [ 1 -eq $get_yzcmds ]; then
     [ -z "$riak_epaths" ] && riak_epaths=`make_app_epaths "${riak_app_config}"`
 
     yz_dir="`epath 'yokozuna root_dir' "$riak_epaths" | sed -e 's/^\"//' -e 's/\".*$//'`"
-    if [ '/' != `echo "$yz_dir" | cut -c1` ]; then
-        # relative path. prepend base dir
-        yz_dir="$riak_base_dir"/"$yz_dir"
-    fi
+    # If Yokozuna is not installed, $yz_dir will be null and cause errors.
+    # Only execute the Yokozuna commands if $yz_dir is not null.
+    if [ -n "$yz_dir" ]; then
+        if [ '/' != `echo "$yz_dir" | cut -c1` ]; then
+            # relative path. prepend base dir
+            yz_dir="$riak_base_dir"/"$yz_dir"
+        fi
 
-    yz_aae_dir="`epath 'yokozuna anti_entropy_data_dir' "$riak_epaths" | sed -e 's/^\"//' -e 's/\".*$//'`"
-    if [ '/' != `echo "$yz_aae_dir" | cut -c1` ]; then
-        # relative path. prepend base dir
-        yz_aae_dir="$riak_base_dir"/"$yz_aae_dir"
-    fi
+        yz_aae_dir="`epath 'yokozuna anti_entropy_data_dir' "$riak_epaths" | sed -e 's/^\"//' -e 's/\".*$//'`"
+        if [ '/' != `echo "$yz_aae_dir" | cut -c1` ]; then
+            # relative path. prepend base dir
+            yz_aae_dir="$riak_base_dir"/"$yz_aae_dir"
+        fi
 
-    if [ -d "$yz_dir" ]; then
-        mkdir_or_die "${start_dir}"/"${debug_dir}"/yokozuna/.info
-        cd "${start_dir}"/"${debug_dir}"/yokozuna
+        if [ -d "$yz_dir" ]; then
+            mkdir_or_die "${start_dir}"/"${debug_dir}"/yokozuna/.info
+            cd "${start_dir}"/"${debug_dir}"/yokozuna
 
-        # grab a listing of the yokozuna directory
-        dump ls_yokozuna_dir ls -lhR "$yz_dir"
+            # grab a listing of the yokozuna directory
+            dump ls_yokozuna_dir ls -lhR "$yz_dir"
 
-        # Take a du listing of the yokozuna directory for size checking.
-        # This info is included in the ls, but parsing ls is not recommended.
-        dump du_yokozuna_dir du "$yz_dir"/*
+            # Take a du listing of the yokozuna directory for size checking.
+            # This info is included in the ls, but parsing ls is not recommended.
+            dump du_yokozuna_dir du "$yz_dir"/*
 
-        # tar up every <schema>/conf directory. This will assure we capture the
-        # schema (regardless of name/extension).
-        cd "$yz_dir"
-        for f in `ls -1 .`; do
-            if [ -d "$f"  -a  -d "$f"/conf ]; then
-               tar -czf ""${start_dir}"/"${debug_dir}"/yokozuna/${f}_conf.tar.gz" "$f"/conf
-            fi
-        done
-    fi
+            # tar up every <schema>/conf directory. This will assure we capture the
+            # schema (regardless of name/extension).
+            cd "$yz_dir"
+            for f in `ls -1 .`; do
+                if [ -d "$f"  -a  -d "$f"/conf ]; then
+                   tar -czf ""${start_dir}"/"${debug_dir}"/yokozuna/${f}_conf.tar.gz" "$f"/conf
+                fi
+            done
+        fi
 
-    if [ -d "$yz_aae_dir" ]; then
-        mkdir_or_die "${start_dir}"/"${debug_dir}"/yokozuna/anti_entropy/.info
-        cd "${start_dir}"/"${debug_dir}"/yokozuna/anti_entropy
+        if [ -d "$yz_aae_dir" ]; then
+            mkdir_or_die "${start_dir}"/"${debug_dir}"/yokozuna/anti_entropy/.info
+            cd "${start_dir}"/"${debug_dir}"/yokozuna/anti_entropy
 
-        # Take a listing of the yz_aae_dir directory for reference
-        dump ls_yokozuna_anti_entropy_dir ls -lhR "$yz_aae_dir"
+            # Take a listing of the yz_aae_dir directory for reference
+            dump ls_yokozuna_anti_entropy_dir ls -lhR "$yz_aae_dir"
 
-        # Take a du listing of the yz_aae_dir directory for size checking.
-        # This info is included in the ls, but parsing ls is not recommended.
-        dump du_yokozuna_anti_entropy_dir du "$yz_aae_dir"/*
+            # Take a du listing of the yz_aae_dir directory for size checking.
+            # This info is included in the ls, but parsing ls is not recommended.
+            dump du_yokozuna_anti_entropy_dir du "$yz_aae_dir"/*
 
-        # Mirror the directory, only copying files that match the pattern
-        cd "$yz_aae_dir"
-        find . -type f -name 'LOG*' -exec sh -c '
-            mkdir -p "$0/${1%/*}";
-            cp "$1" "$0/$1"
-            ' "${start_dir}"/"${debug_dir}"/yokozuna/anti_entropy {} \;
+            # Mirror the directory, only copying files that match the pattern
+            cd "$yz_aae_dir"
+            find . -type f -name 'LOG*' -exec sh -c '
+                mkdir -p "$0/${1%/*}";
+                cp "$1" "$0/$1"
+                ' "${start_dir}"/"${debug_dir}"/yokozuna/anti_entropy {} \;
+        fi
     fi
 fi
 
@@ -591,7 +602,7 @@ fi
 if [ 1 -eq $get_extracmds ]; then
     mkdir_or_die "${start_dir}"/"${debug_dir}"/commands/.info
     cd "${start_dir}"/"${debug_dir}"/commands
-    dump riak_vnode_status "$riak_bin_dir"/riak-admin vnode-status
+    dump riak_vnode_status "$riak_bin_dir"/riak admin vnode-status
 fi
 
 ###
@@ -716,6 +727,30 @@ if [ 1 -eq $get_logs ]; then
         # This info is included in the ls, but parsing ls is not recommended.
         dump du_bitcask_dir du "$bitcask_dir"/*
 
+    elif [ 'riak_kv_leveled_backend' = "$backend" ]; then
+        leveled_dir="`epath 'leveled data_root' "$riak_epaths" | sed -e 's/^\"//' -e 's/\".*$//'`"
+
+        if [ '/' != `echo "$bitcask_dir" | cut -c1` ]; then
+            # relative path. prepend base dir
+            leveled_dir="$riak_base_dir"/"$leveled_dir"
+        fi
+
+        if [ ! -d "$bitcask_dir" ]; then
+            echoerr "Unable to locate Leveled data directory. Aborting."
+            echoerr "Using leveled data_root: $leveled_dir"
+            exit 1
+        fi
+
+        mkdir_or_die "${start_dir}"/"${debug_dir}"/logs/leveled/.info
+        cd "${start_dir}"/"${debug_dir}"/logs/leveled
+
+        # Take a listing of the bitcask directory for reference
+        dump ls_leveled_dir ls -lhR "$leveled_dir"
+
+        # Take a du listing of the bitcask directory for size checking.
+        # This info is included in the ls, but parsing ls is not recommended.
+        dump du_leveled_dir du "$leveled_dir"/*
+
     # Walk multi-backends and collect whatever information is there to collect.
     elif [ 'riak_kv_multi_backend' = "$backend" ] ||
          [ 'riak_cs_kv_multi_backend' = "$backend" ] ; then
@@ -778,6 +813,31 @@ if [ 1 -eq $get_logs ]; then
                 # This info is included in the ls, but parsing ls is not recommended.
                 dump du_bitcask_dir du "$dr"/*
             fi
+            elif [ 'riak_kv_leveled_backend' = "$backend" ]; then
+                dr="`epath "riak_kv multi_backend $b riak_kv_leveled_backend data_root" "$riak_epaths" |
+                    sed -e 's/^\"//' -e 's/\".*$//'`"
+
+                if [ '/' != `echo "$dr" | cut -c1` ]; then
+                    # relative path. prepend base dir
+                    dr="$riak_base_dir"/"$dr"
+                fi
+
+                if [ ! -d "${dr}" ]; then
+                    echoerr "Unable to locate $b Leveled data directory. Aborting."
+                    echoerr "Using riak_kv_leveled_backend data_root: $dr"
+                    exit 1
+                fi
+
+                mkdir_or_die "${start_dir}"/"${debug_dir}"/logs/leveled-${b}/.info
+                cd "${start_dir}"/"${debug_dir}"/logs/leveled-${b}
+
+                # Take a listing of the bitcask directory for reference
+                dump ls_leveled_dir ls -lhR "$dr"
+
+                # Take a du listing of the bitcask directory for size checking.
+                # This info is included in the ls, but parsing ls is not recommended.
+                dump du_leveled_dir du "$dr"/*
+            fi
         done
     fi
 
@@ -810,6 +870,36 @@ if [ 1 -eq $get_logs ]; then
             mkdir -p "$0/${1%/*}";
             cp "$1" "$0/$1"
             ' "${start_dir}"/"${debug_dir}"/logs/anti_entropy {} \;
+    fi
+    # Gather AAE logs, listing, sizing information, etc..
+    # Calling `epath 'riak_kv tictacaae' "$riak_epaths. . .` will result in
+    # an empty variable regardless of the value set in the configuration
+    # settings. We're going to grab the `tictacaae_dataroot` instead, and
+    # assume it's presence on disk indicates activity.
+    tictacaae_dir="`epath 'riak_kv tictacaae_dataroot' "$riak_epaths" | sed -e 's/^\"//' -e 's/\".*$//'`"
+
+    if [ '/' != `echo "$tictacaae_dir" | cut -c1` ]; then
+        # relative path. prepend base dir
+        tictacaae_dir="$riak_base_dir"/"$tictacaae_dir"
+    fi
+
+    if [ -d "$tictacaae_dir" ]; then
+        mkdir_or_die "${start_dir}"/"${debug_dir}"/logs/tictacaae/.info
+        cd "${start_dir}"/"${debug_dir}"/logs/tictacaae
+
+        # Take a listing of the anti_entropy_dir directory for reference
+        dump ls_tictacaae_dir ls -lhR "$tictacaae_dir"
+
+        # Take a du listing of the anti_entropy_dir directory for size checking.
+        # This info is included in the ls, but parsing ls is not recommended.
+        dump du_tictacaae_dir du "$tictacaae_dir"/*
+
+        # Mirror the directory, only copying files that match the pattern
+        cd "$tictacaae_dir"
+        find . -type f -name 'LOG*' -exec sh -c '
+            mkdir -p "$0/${1%/*}";
+            cp "$1" "$0/$1"
+            ' "${start_dir}"/"${debug_dir}"/logs/tictacaae {} \;
     fi
 fi
 

--- a/rel/files/riak-debug
+++ b/rel/files/riak-debug
@@ -812,7 +812,6 @@ if [ 1 -eq $get_logs ]; then
                 # Take a du listing of the bitcask directory for size checking.
                 # This info is included in the ls, but parsing ls is not recommended.
                 dump du_bitcask_dir du "$dr"/*
-            fi
             elif [ 'riak_kv_leveled_backend' = "$backend" ]; then
                 dr="`epath "riak_kv multi_backend $b riak_kv_leveled_backend data_root" "$riak_epaths" |
                     sed -e 's/^\"//' -e 's/\".*$//'`"

--- a/rel/files/riak-debug
+++ b/rel/files/riak-debug
@@ -602,7 +602,7 @@ fi
 if [ 1 -eq $get_extracmds ]; then
     mkdir_or_die "${start_dir}"/"${debug_dir}"/commands/.info
     cd "${start_dir}"/"${debug_dir}"/commands
-    dump riak_vnode_status "$riak_bin_dir"/riak admin vnode-status
+    dump riak_vnode_status "$riak_sbin_dir"/riak admin vnode-status
 fi
 
 ###

--- a/rel/files/riak-debug
+++ b/rel/files/riak-debug
@@ -473,12 +473,11 @@ if [ 1 -eq $get_riakcmds ]; then
     # nodes in a cluster.
 
     dump riak_ping "$riak_sbin_dir"/riak ping
-    dump riak_version "$riak_sbin_dir"/riak version
+    dump riak_version "$riak_sbin_dir"/riak versions
     dump riak_member_status "$riak_sbin_dir"/riak admin member-status
     dump riak_ring_status "$riak_sbin_dir"/riak admin ring-status
     dump riak_status "$riak_sbin_dir"/riak admin status
     dump riak_transfers "$riak_sbin_dir"/riak admin transfers
-    dump riak_search_aae_status "$riak_sbin_dir"/riak admin search aae-status
     dump riak_diag "$riak_sbin_dir"/riak admin diag
     dump riak_repl_status "$riak_sbin_dir"/riak repl status
     dump riak_repl_connections "$riak_sbin_dir"/riak repl connections
@@ -903,24 +902,24 @@ if [ 1 -eq $get_logs ]; then
 fi
 
 ###
-### Gather Riak's basho-patches directory
+### Gather Riak's patches directory
 ###
 
 if [ 1 -eq $get_patches ]; then
-    mkdir_or_die "${start_dir}"/"${debug_dir}"/basho-patches/.info
-    cd "${start_dir}"/"${debug_dir}"/basho-patches
+    mkdir_or_die "${start_dir}"/"${debug_dir}"/patches/.info
+    cd "${start_dir}"/"${debug_dir}"/patches
 
     # As per the below link, this patch should be based off the base_dir.
     # http://docs.basho.com/riakee/latest/cookbooks/Rolling-Upgrade-to-Enterprise/#Basho-Patches
-    riak_lib_dir="${riak_base_dir}/lib/basho-patches"
+    riak_lib_dir="${riak_base_dir}/lib/patches"
 
     # Use dump to execute the copy. This will provide a progress dot and
     # capture any error messages.
-    dump cp_basho_patches cp -R "$riak_lib_dir"/* .
+    dump cp_patches cp -R "$riak_lib_dir"/* .
 
     # If the copy succeeded, then the output will be empty and it is unneeded.
     if [ 0 -eq $? ]; then
-        rm -f cp_basho_patches
+        rm -f cp_patches
     fi
 fi
 

--- a/rel/pkg/deb/debian/postinst
+++ b/rel/pkg/deb/debian/postinst
@@ -23,6 +23,8 @@ for i in lib log; do
     chown -R riak:riak /var/$i/riak
 done
 
+ln -s /usr/lib/riak/bin/riak-debug /usr/sbin/riak-debug
+
 case "$1" in
     configure)
     ;;

--- a/rel/pkg/rpm/specfile
+++ b/rel/pkg/rpm/specfile
@@ -122,7 +122,7 @@ fi
 
 %post
 # Post Installation Script
-
+ln -s /usr/lib64/riak/bin/riak-debug /usr/sbin/riak-debug 
 # For distros with SELinux (RHEL/Fedora)
 if [ `which selinuxenabled > /dev/null 2>&1` ] ; then
    # Fixup perms for SELinux (if it is enabled)


### PR DESCRIPTION
This fix addresses https://github.com/basho/riak/issues/1037 by doing the following:

- re-adding `app_epath.sh` from Riak KV 2.9.7 to `/usr/lib64/riak/lib` on rpm builds and `/usr/lib/riak/lib` on deb builds from `/rel/files/` via an edit to `rebar.config`.
- applying numerous fixes to `/rel/files/riak-debug` to render it compatible with KV 3.0.1.
- as `/usr/sbin/riak debug` actually executes `/usr/lib64/riak/bin/riak-debug -s` for reasons I could neither determine nor fix, I have made a work-around for this by adding a symlink from `riak-debug` to `/usr/sbin` in the post-install script for the packages.
- added a capture of directory structure for tictacaae and leveled.

The symlinks are only a temporary work-around. Once I have worked out why `riak debug` executes `riak-debug -s` and fixed it, I'll submit another pull request to update for that and remove the symlinks.