### PR TITLE
fix: Remove - flag from su in riak startup script

### DIFF
--- a/rel/files/riak
+++ b/rel/files/riak
@@ -39,7 +39,7 @@ else
     fi
     case "$1" in
         start|console|foreground)
-            su - riak -c "RELX_CONFIG_PATH=${RELX_CONFIG_PATH} VMARGS_PATH=${VMARGS_PATH} RUNNER_LOG_DIR=${RUNNER_LOG_DIR} PIPE_DIR=${PIPE_DIR} ${COMMAND} ${*} -pa {{platform_lib_dir}}/patches"
+            su riak -c "RELX_CONFIG_PATH=${RELX_CONFIG_PATH} VMARGS_PATH=${VMARGS_PATH} RUNNER_LOG_DIR=${RUNNER_LOG_DIR} PIPE_DIR=${PIPE_DIR} ${COMMAND} ${*} -pa {{platform_lib_dir}}/patches"
             ;;
         debug)
             # Drop the "debug" from the args as we're going to directly call riak-debug now
@@ -49,9 +49,7 @@ else
             ;;
         *)
             ESCAPED_ARGS=`echo "$@" | sed -e 's/\([\\\(\\\){}"\x27]\)/\\\\\1/g'`
-            su - riak -c "RELX_CONFIG_PATH=${RELX_CONFIG_PATH} VMARGS_PATH=${VMARGS_PATH} RUNNER_LOG_DIR=${RUNNER_LOG_DIR} PIPE_DIR=${PIPE_DIR} ${COMMAND} ${ESCAPED_ARGS}"
+            su riak -c "RELX_CONFIG_PATH=${RELX_CONFIG_PATH} VMARGS_PATH=${VMARGS_PATH} RUNNER_LOG_DIR=${RUNNER_LOG_DIR} PIPE_DIR=${PIPE_DIR} ${COMMAND} ${ESCAPED_ARGS}"
             ;;
     esac
 fi
-
-


### PR DESCRIPTION
This is more of a request for comments than an actual PR.

Recently while tweaking [our base image](https://github.com/rbkmoney/image-riak-base) we've discovered that it's practically impossible to pass env variables (such as `WAIT_FOR_ERLANG`) from script.

I believe the reasons for this are the `su` lines with env passing turned off explicitly (via `-` aka `-l` flag) here:
- https://github.com/basho/riak/tree/ff65b0a2ac63dcb5fca5add95cb1b72bb7e8676a/rel/files/riak#L42
- https://github.com/basho/riak/tree/ff65b0a2ac63dcb5fca5add95cb1b72bb7e8676a/rel/files/riak#L52

As well as `su`d commands in node_package:
- https://github.com/basho/node_package/tree/a541c79bb65fb4ac6f60197c333f841065d0aff6/priv/base/env.sh#L246

As a workaround, [preliminary `su` to runner user (`riak`) in this case was used with passed env](https://github.com/rbkmoney/image-riak-base/pull/20/files).

It left us wondering: was it done by purpose? Safety net of sorts to ensure safe environment?