### PR TITLE
Update Riak rpm naming to match global standards

### DIFF
--- a/rel/pkg/rpm/Makefile
+++ b/rel/pkg/rpm/Makefile
@@ -6,7 +6,7 @@ PWD    = $(shell pwd)
 PKG_VERSION_NO_H	?= $(shell echo $(PKG_VERSION) | tr - .)
 
 default:
-	rpmbuild --define "_rpmfilename %%{NAME}-%%{VERSION}-%%{RELEASE}$(DISTRO)%%{ARCH}.rpm" \
+	rpmbuild --define "_rpmfilename %%{NAME}-%%{VERSION}-%%{RELEASE}$(DISTRO).%%{ARCH}.rpm" \
 		--define '_topdir $(BASE_DIR)/rel/pkg/out/' \
 		--define '_sourcedir $(BASE_DIR)/rel/pkg/out/' \
 		--define '_specdir $(BASE_DIR)/rel/pkg/out/' \


### PR DESCRIPTION
Currently, when building rpm packages, riak-2.x.x names correctly e.g. `riak-2.9.8-1.el8.x86_64.rpm` but the riak-3.x.x rpms are missing a dot before the basearch i.e. `riak-3.0.6-1.el8x86_64.rpm`. This incredibly tiny fix re-adds the missing dot in the package name.

I have already tested this successfully on one of the regular package builders we use to publish the binaries by creating a phony tag of riak-3.0.61 and building it accordingly:
```
[root@localhost riak]# ls rel/pkg/out/packages/
riak-3.0.61.OTP20.3-1.el8.src.rpm      riak-3.0.61.OTP20.3-1.el8.x86_64.rpm 
riak-3.0.61.OTP20.3-1.el8.src.rpm.sha  riak-3.0.61.OTP20.3-1.el8.x86_64.rpm.sha
```