### PR TITLE
Add pre_start to set as interactive

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -94,6 +94,7 @@
 
          {copy, "rel/files/check_ulimit",       "bin/hooks/check_ulimit"},
          {copy, "rel/files/erl_maxlogsize",     "bin/hooks/erl_maxlogsize"},
+         {copy, "rel/files/erl_codeloadingmode","bin/hooks/erl_codeloadingmode"},
          {copy, "rel/files/riak_not_running",   "bin/hooks/riak_not_running"},
          {copy, "rel/files/app_epath.sh",       "lib/app_epath.sh"}
 
@@ -119,7 +120,8 @@
                 [{pre_start,
                     [{custom, "hooks/riak_not_running"},
                     {custom, "hooks/check_ulimit"},
-                    {custom, "hooks/erl_maxlogsize"}]},
+                    {custom, "hooks/erl_maxlogsize"},
+                    {custom, "hooks/erl_codeloadingmode"}]},
                 {post_start,
                 [{wait_for_process, riak_core_node_watcher}]}
                 ]}
@@ -131,7 +133,8 @@
                     [{pre_start,
                         [{custom, "hooks/riak_not_running"},
                         {custom, "hooks/check_ulimit"},
-                        {custom, "hooks/erl_maxlogsize"}]},
+                        {custom, "hooks/erl_maxlogsize"},
+                        {custom, "hooks/erl_codeloadingmode"}]},
                     {post_start,
                         [{wait_for_process, riak_core_node_watcher}]}
                     ]}
@@ -148,7 +151,8 @@
                     [{pre_start,
                         [{custom, "hooks/riak_not_running"},
                         {custom, "hooks/check_ulimit"},
-                        {custom, "hooks/erl_maxlogsize"}]},
+                        {custom, "hooks/erl_maxlogsize"},
+                        {custom, "hooks/erl_codeloadingmode"}]},
                     {post_start,
                         [{pid, "/var/run/riak/riak.pid"},
                         {wait_for_process, riak_core_node_watcher}]}
@@ -165,7 +169,8 @@
                     [{pre_start,
                         [{custom, "hooks/riak_not_running"},
                         {custom, "hooks/check_ulimit"},
-                        {custom, "hooks/erl_maxlogsize"}]},
+                        {custom, "hooks/erl_maxlogsize"},
+                        {custom, "hooks/erl_codeloadingmode"}]},
                     {post_start,
                         [wait_for_vm_start,
                             {pid, "/run/riak/riak.pid"},

--- a/rel/files/erl_codeloadingmode
+++ b/rel/files/erl_codeloadingmode
@@ -1,0 +1,3 @@
+#!/bin/sh
+CODE_LOADING_MODE="${CODE_LOADING_MODE:-interactive}"
+export CODE_LOADING_MODE


### PR DESCRIPTION
Returns riak to pre-3.0 default of interactive mode, by setting a pre-start script.

Should be possible to override by setting the environment variable before starting (if one wishes to run embedded).  Required for user-added code (e.g. to find user-defined map/reduce functions)