### PR TITLE
pass NODETOOL_NODE_PREFIX to relx-generated script, spare some atoms

### DIFF
--- a/rel/files/riak
+++ b/rel/files/riak
@@ -39,17 +39,17 @@ else
     fi
     case "$1" in
         start|console|foreground)
-            su - riak -c "RELX_CONFIG_PATH=${RELX_CONFIG_PATH} VMARGS_PATH=${VMARGS_PATH} RUNNER_LOG_DIR=${RUNNER_LOG_DIR} PIPE_DIR=${PIPE_DIR} ${COMMAND} ${*} -pa {{platform_lib_dir}}/patches"
+            su - riak -c "NODETOOL_NODE_PREFIX=${NODETOOL_NODE_PREFIX} RELX_CONFIG_PATH=${RELX_CONFIG_PATH} VMARGS_PATH=${VMARGS_PATH} RUNNER_LOG_DIR=${RUNNER_LOG_DIR} PIPE_DIR=${PIPE_DIR} ${COMMAND} ${*} -pa {{platform_lib_dir}}/patches"
             ;;
         debug)
             # Drop the "debug" from the args as we're going to directly call riak-debug now
             shift
             # Debug may fail if run via relx script due to use of relative start location, and also need for root access
-            RELX_CONFIG_PATH=${RELX_CONFIG_PATH} VMARGS_PATH=${VMARGS_PATH} RUNNER_LOG_DIR=${RUNNER_LOG_DIR} PIPE_DIR=${PIPE_DIR} ${DEBUG_COMMAND} ${*}
+            NODETOOL_NODE_PREFIX=${NODETOOL_NODE_PREFIX} RELX_CONFIG_PATH=${RELX_CONFIG_PATH} VMARGS_PATH=${VMARGS_PATH} RUNNER_LOG_DIR=${RUNNER_LOG_DIR} PIPE_DIR=${PIPE_DIR} ${DEBUG_COMMAND} ${*}
             ;;
         *)
             ESCAPED_ARGS=`echo "$@" | sed -e 's/\([\\\(\\\){}"\x27]\)/\\\\\1/g'`
-            su - riak -c "RELX_CONFIG_PATH=${RELX_CONFIG_PATH} VMARGS_PATH=${VMARGS_PATH} RUNNER_LOG_DIR=${RUNNER_LOG_DIR} PIPE_DIR=${PIPE_DIR} ${COMMAND} ${ESCAPED_ARGS}"
+            su - riak -c "NODETOOL_NODE_PREFIX=${NODETOOL_NODE_PREFIX} RELX_CONFIG_PATH=${RELX_CONFIG_PATH} VMARGS_PATH=${VMARGS_PATH} RUNNER_LOG_DIR=${RUNNER_LOG_DIR} PIPE_DIR=${PIPE_DIR} ${COMMAND} ${ESCAPED_ARGS}"
             ;;
     esac
 fi


### PR DESCRIPTION
Each time `riak status` (and the like) is run, relx generates a unique id which is then converted to an atom (of the form "maint1a2b3c4d-riak@127.0.0.1") in the riak VM to which it connects, eventually causing atom table exhaustion.  Now that relx has been [modified](https://github.com/erlware/relx/pull/871) to optionally produce a static id if `NODETOOL_NODE_PREFIX` env var is present instead of generating a random id, let's make use of this. Convenient when the caller guarantees calls are always serialized.