### PR TITLE
Unify patcher directory in riak scripts

### DIFF
--- a/rel/files/riak
+++ b/rel/files/riak
@@ -24,7 +24,7 @@ fi
 if [[ $EUID -ne 0 ]]; then
     case "$1" in
         start|console|foreground)
-            RELX_CONFIG_PATH=${RELX_CONFIG_PATH} VMARGS_PATH=${VMARGS_PATH} RUNNER_LOG_DIR=${RUNNER_LOG_DIR} PIPE_DIR=${PIPE_DIR} ${COMMAND} ${*} -pa {{platform_lib_dir}}/patches
+            RELX_CONFIG_PATH=${RELX_CONFIG_PATH} VMARGS_PATH=${VMARGS_PATH} RUNNER_LOG_DIR=${RUNNER_LOG_DIR} PIPE_DIR=${PIPE_DIR} ${COMMAND} ${*} -pa {{runner_patch_dir}}
             ;;
         *)
             RELX_CONFIG_PATH=${RELX_CONFIG_PATH} VMARGS_PATH=${VMARGS_PATH} RUNNER_LOG_DIR=${RUNNER_LOG_DIR} PIPE_DIR=${PIPE_DIR} ${COMMAND} ${*}
@@ -39,7 +39,7 @@ else
     fi
     case "$1" in
         start|console|foreground)
-            su - riak -c "NODETOOL_NODE_PREFIX=${NODETOOL_NODE_PREFIX} RELX_CONFIG_PATH=${RELX_CONFIG_PATH} VMARGS_PATH=${VMARGS_PATH} RUNNER_LOG_DIR=${RUNNER_LOG_DIR} PIPE_DIR=${PIPE_DIR} ${COMMAND} ${*} -pa {{platform_lib_dir}}/patches"
+            su - riak -c "NODETOOL_NODE_PREFIX=${NODETOOL_NODE_PREFIX} RELX_CONFIG_PATH=${RELX_CONFIG_PATH} VMARGS_PATH=${VMARGS_PATH} RUNNER_LOG_DIR=${RUNNER_LOG_DIR} PIPE_DIR=${PIPE_DIR} ${COMMAND} ${*} -pa {{runner_patch_dir}}"
             ;;
         debug)
             # Drop the "debug" from the args as we're going to directly call riak-debug now

--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -919,7 +919,7 @@ case "$1" in
         OLDNODE=$1
         NEWNODE=$2
         $ERTS_PATH/erl -noshell \
-            -pa $RUNNER_LIB_DIR/basho-patches \
+            -pa {{runner_patch_dir}} \
             -boot $BOOT_FILE \
             $CONFIG_ARGS \
             -eval "riak_kv_console:$ACTION(['$OLDNODE', '$NEWNODE'])" \
@@ -940,7 +940,7 @@ case "$1" in
         FILENAME=$3
 
         $ERTS_PATH/erl -noshell $NAME_PARAM riak_kv_backup$NAME_HOST -setcookie $COOKIE \
-                       -pa $RUNNER_LIB_DIR/basho-patches \
+                       -pa {{runner_patch_dir}} \
                        -boot $BOOT_FILE \
                        -eval "riak_kv_backup:$ACTION('$NODE', \"$FILENAME\")" -s init stop
         ;;
@@ -960,7 +960,7 @@ case "$1" in
         TYPE=$4
 
         $ERTS_PATH/erl -noshell $NAME_PARAM riak_kv_backup$NAME_HOST -setcookie $COOKIE \
-                       -pa $RUNNER_LIB_DIR/basho-patches \
+                       -pa {{runner_patch_dir}} \
                        -boot $BOOT_FILE \
                        -eval "riak_kv_backup:$ACTION('$NODE', \"$FILENAME\", \"$TYPE\")" -s init stop
         ;;
@@ -974,7 +974,7 @@ case "$1" in
         NODE_NAME=${NAME_ARG#* }
 
         $ERTS_PATH/erl -noshell $NAME_PARAM riak_test$NAME_HOST $COOKIE_ARG \
-                       -pa $RUNNER_LIB_DIR/basho-patches \
+                       -pa {{runner_patch_dir}} \
                        -boot $BOOT_FILE \
                        -eval "case catch(riak:client_test(\"$NODE_NAME\")) of \
                                ok -> init:stop();                             \
@@ -1010,7 +1010,7 @@ case "$1" in
         NODE_NAME=${NAME_ARG#* }
         # Using np_etop instead of riak_etop to follow node_package convention
         $ERTS_PATH/erl -noshell -noinput \
-            -pa $RUNNER_LIB_DIR/basho-patches \
+            -pa {{runner_patch_dir}} \
             -boot $BOOT_FILE \
             -hidden $NAME_PARAM np_etop$RAND$NAME_HOST $COOKIE_ARG \
             -s etop -s erlang halt -output text \

--- a/rel/files/riak-debug
+++ b/rel/files/riak-debug
@@ -106,7 +106,7 @@ Usage: riak-debug [-c] [-l] [-r] [-s] [-e] [-v] [FILENAME | -]
                 .p12, .csr, .sst, .sto, .stl, .pem, .key.
                 Please see the Privacy Note below.
 -l, --logs      Gather Riak logs.
--p, --patches   Gather the contents of the basho-patches directory.
+-p, --patches   Gather the contents of the patches directory.
 -r, --riakcmds  Gather Riak information and command output.
 -y, --yzmcmds   Gather yokozuna information and logs.
 -s, --syscmds   Gather general system commands.

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -42,7 +42,7 @@
 {runner_etc_dir,     "$RUNNER_BASE_DIR/etc"}.
 {runner_log_dir,     "$RUNNER_BASE_DIR/log"}.
 {runner_lib_dir,     "$RUNNER_BASE_DIR/lib"}.
-{runner_patch_dir,   "$RUNNER_BASE_DIR/lib/basho-patches"}.
+{runner_patch_dir,   "$RUNNER_BASE_DIR/lib/patches"}.
 {pipe_dir,           "/tmp/$RUNNER_BASE_DIR/"}.
 {runner_user,        ""}.
 {runner_wait_process, "riak_core_node_watcher"}.


### PR DESCRIPTION
Use runner_patch_dir template variable as common entry for patch directory across riak scripts.