### PR TITLE
fixes for packaging regressions for 3.2.1

### DIFF
--- a/rel/files/riak
+++ b/rel/files/riak
@@ -8,6 +8,13 @@ export RUNNER_LOG_DIR={{platform_log_dir}}
 mkdir -p $PID_DIR
 chown riak:riak $PID_DIR
 
+# cuttlefish should be doing this, but it doesn't:
+VMARGS_PATH=`ls -1 ${RUNNER_GEN_DIR}/generated.conf/vm.*.args 2>/dev/null | tail -1`
+if [ ! -r  "$VMARGS_PATH" ]; then
+    VMARGS_PATH="{{platform_base_dir}}/releases/{{rel_vsn}}/vm.args"
+fi
+export VMARGS_PATH
+
 # centos7-based distros have a su that contacts pam and prints the "Last logged in" message
 if [ "`cat /etc/redhat-release 2>&1`" = "CentOS Stream release 7" ] ||
    [ "`cat /etc/system-release 2>&1`" = "Amazon Linux release 2 (Karoo)" ]; then

--- a/rel/pkg/alpine/riak-nosu
+++ b/rel/pkg/alpine/riak-nosu
@@ -4,6 +4,13 @@ RUNNER_GEN_DIR={{platform_gen_dir}}
 RELX_RIAK={{platform_bin_dir}}/riak
 export PID_DIR={{pid_dir}}
 
+# cuttlefish should be doing this, but it doesn't:
+VMARGS_PATH=`ls -1 ${RUNNER_GEN_DIR}/generated.conf/vm.*.args 2>/dev/null | tail -1`
+if [ ! -r  "$VMARGS_PATH" ]; then
+    VMARGS_PATH="{{platform_base_dir}}/releases/{{rel_vsn}}/vm.args"
+fi
+export VMARGS_PATH
+
 mkdir -p $PID_DIR
 
 case "$1" in

--- a/rel/pkg/alpine/vars.config
+++ b/rel/pkg/alpine/vars.config
@@ -3,34 +3,44 @@
 
 {rel_vsn, "{{release_version}}"}.
 
-{platform_base_dir,  "/usr/lib/riak"}.
-{platform_bin_dir,   "/usr/lib/riak/bin"}.
-{platform_data_dir,  "/var/lib/riak"}.
-{platform_etc_dir,   "/etc/riak"}.
-{platform_lib_dir,   "/usr/lib/riak/lib"}.
-{platform_log_dir,   "/var/log/riak"}.
-{platform_gen_dir,   "/var/lib/riak/releases"}.
+%% Platform-specific installation paths
+{platform_bin_dir,  "/usr/lib/riak/bin"}.
+{platform_data_dir, "/var/lib/riak"}.
+{platform_etc_dir,  "/etc/riak"}.
+{platform_base_dir, "/usr/lib/riak"}.
+{platform_lib_dir,  "/usr/lib/riak/lib"}.
+{platform_log_dir,  "/var/log/riak"}.
+{platform_gen_dir,  "/var/lib/riak"}.
 {platform_patch_dir, "/usr/lib/riak/lib/patches"}.
 
 {pid_dir,            "/run/riak"}.
 
-{web_ip,                "127.0.0.1"}.
-{web_port,              8098}.
 {cluster_manager_ip,    "127.0.0.1"}.
 {cluster_manager_port,  9080}.
-{handoff_port,          8099}.
-{handoff_ip,            "0.0.0.0"}.
-{pb_ip,                 "127.0.0.1"}.
-{pb_port,               8087}.
+
+{web_ip,            "127.0.0.1"}.
+{web_port,          8098}.
+{handoff_ip,        "0.0.0.0"}.
+{handoff_port,      8099}.
+{pb_ip,             "127.0.0.1"}.
+{pb_port,           8087}.
+
 {storage_backend,   "bitcask"}.
+
 {sasl_error_log,    "{{platform_log_dir}}/sasl-error.log"}.
 {sasl_log_dir,      "{{platform_log_dir}}/sasl"}.
-{repl_data_root,    "{{platform_data_dir}}/riak_repl/"}.
+{repl_data_root,    "{{platform_data_dir}}/riak_repl"}.
+{crash_dump,        "{{platform_log_dir}}/erl_crash.dump"}.
 
-{console_log_default, file}.
-
-{node,         "riak@127.0.0.1"}.
-{crash_dump,   "{{platform_log_dir}}/erl_crash.dump"}.
-
+%%
+%% cuttlefish
+%%
 {cuttlefish,         "on"}.
 {cuttlefish_conf,    "riak.conf"}.
+
+{logger_level, info}.
+
+%%
+%% etc/vm.args
+%%
+{node,         "riak@127.0.0.1"}.

--- a/rel/pkg/deb/debian/riak.riak.service
+++ b/rel/pkg/deb/debian/riak.riak.service
@@ -3,7 +3,7 @@ Description=Riak KV Database
 
 [Service]
 User=riak
-ExecStart=/usr/sbin/riak foreground
+ExecStart=/usr/sbin/riak start
 ExecStop=/usr/sbin/riak stop
 Type=simple
 PIDFile=/run/riak/riak.pid

--- a/rel/pkg/fbsdng/Makefile
+++ b/rel/pkg/fbsdng/Makefile
@@ -97,6 +97,8 @@ $(BUILD_STAGE_DIR): buildrel
 #  * copy the vars.config over for build config
 buildrel:
 	tar -xf $(BASE_DIR)/rel/pkg/out/$(PKG_ID).tar.gz -C $(BASE_DIR)/rel/pkg/out/$(PKG_ID)
+	cd $(BASE_DIR)/rel/pkg/out/$(PKG_ID); \
+	(mkdir -p _build/default && cd _build/default && for d in lib; do ln -fs $(BASE_DIR)/_build/default/$$d; done); \
 	$(MAKE) -C $(BASE_DIR)/rel/pkg/out/$(PKG_ID) rel-fbsdng
 	rm -rf rel/riak/lib/*/c_src rel/riak/lib/*/src
 	chmod 0755 rel/riak/bin/* rel/riak/erts-*/bin/*

--- a/rel/pkg/rpm/riak.service
+++ b/rel/pkg/rpm/riak.service
@@ -3,7 +3,7 @@ Description=Riak KV Database
 
 [Service]
 User=riak
-ExecStart=/usr/sbin/riak foreground
+ExecStart=/usr/sbin/riak start
 ExecStop=/usr/sbin/riak stop
 Type=simple
 PIDFile=/run/riak/riak.pid


### PR DESCRIPTION
Fixes for a couple of regressions discovered while packaging riak-3.2.0:

* When riak was started via systemctl, the .service unit file had `riak foreground` (blindly following an advice from riak launcher script generated by rebar3.18), which resulted in pipe files in /tmp/erl_pipes/riak@127.0.0.1 not being created as they should be for `riak attach` to work. Whether it is a bug or feature in relx that comes with rebar3.18, is a matter for rebar3 developers to comment or investigate; for the time being, [changing](https://github.com/basho/riak/commit/18fb795835f104907527d157be5e3ed294a313cd) the starting command (back) to `riak start` appears to be sufficient.
* If riak launcher script finds an empty VMARGS_PATH, it extracts `node` from the default vm.args which will always be set to "riak@127.0.0.1", while the proper value, as specified in /etc/riak.conf, is to be found in generated.conf/vm.*.args. It's probably cuttlefish's task to take care of it by exporting VMARGS_PATH, but it doesn't currently do so, meaning we should [do it](https://github.com/basho/riak/commit/2c41a8443a37e1f36f5cbdea1d47769ef22392e2) ourselves.
* An [optimisation](https://github.com/basho/riak/commit/35d5c3f42acc1e6a5fcb68eccfaa258a34897b0a) that allows packagers (me) to reuse previously fetched deps and avoid downloading 100s of megs every time  `make package` is run (similar optimisations have already been included for deb and rpm flavors).
* An update of vars.config for alpine that should have been included in #1114 but wasn't.