### PR TITLE
added detailed compilation and running instructions for Ubuntu 22.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 To build riak, Erlang OTP 22 or higher is required.
 
+To install and run on Ubuntu 22
+
+1. sudo apt upgrade
+2. sudo apt update
+3. sudo apt install build-essential
+4. sudo apt install libpam0g-dev
+5. sudo apt install erlang
+6. sudo apt install cmake
+7. Go to the riak GitHub repo and clone the repo (https://github.com/basho/riak)
+8.  cd riak
+9. sudo ./rebar3 get-deps
+10. sudo make rel
+11. Edit riak/rel/riak/etc/riak.config following the user  [documentation](https://www.tiot.jp/riak-docs/riak/kv/2.9.10/) or the [legacy documentation](https://docs.riak.com/riak/kv/latest/index.html)
+12. sudo riak daemon
+
 `make rel` will build a release which can be run via `rel/riak/bin/riak start`.  Riak is primarily configured via `rel/riak/etc/riak.conf`
 
 To make a package, install appropriate build tools for your operating system and run `make package`.


### PR DESCRIPTION
I've added detailed instructions for Ubuntu 20.* including the required dependencies for the compilation.

My plan is to add instructions for other versions of Linux and MacOS. I'll do these one at a time. I left the old documentation in. I've also not decided how to arrange the document (Headers, etc.)