### PR TITLE
Update riak-admin escape to use printf instead of echo

### DIFF
--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -555,7 +555,7 @@ The following commands modify users and security ACLs for Riak:
 }
 
 escape() {
-    echo -n "$1" | sed 's/"/\\"/g'
+    printf '%s' "$1" | sed 's/"/\\"/g'
 }
 
 btype_admin()


### PR DESCRIPTION
`echo` is not the most portable method to pipe output. In some systems `echo -n hello` will output `"-n hello"`.  I was experiencing this when getting an "invalid JSON" error while creating buckets with `riak admin`. `printf` is a more reliable way to "echo" variables without newlines.